### PR TITLE
Modify the initialization and expansion of the chip status

### DIFF
--- a/bsp/esp32_s3_touch_amoled_1_8/esp32_s3_touch_amoled_1_8.c
+++ b/bsp/esp32_s3_touch_amoled_1_8/esp32_s3_touch_amoled_1_8.c
@@ -404,14 +404,6 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
         .vendor_config = &vendor_config,
     };
     ESP_ERROR_CHECK(esp_lcd_new_panel_sh8601(io_handle, &panel_config, &panel_handle));
-
-    esp_io_expander_handle_t expander = bsp_io_expander_init();
-    esp_io_expander_set_dir(expander, IO_EXPANDER_PIN_NUM_0 | IO_EXPANDER_PIN_NUM_1 |IO_EXPANDER_PIN_NUM_2, IO_EXPANDER_OUTPUT);
-    esp_io_expander_set_level(expander, IO_EXPANDER_PIN_NUM_0 | IO_EXPANDER_PIN_NUM_1|IO_EXPANDER_PIN_NUM_2, 1);
-    vTaskDelay(pdMS_TO_TICKS(100));
-    esp_io_expander_set_level(expander, IO_EXPANDER_PIN_NUM_0 | IO_EXPANDER_PIN_NUM_1|IO_EXPANDER_PIN_NUM_2, 0);
-    vTaskDelay(pdMS_TO_TICKS(100));
-    esp_io_expander_set_level(expander, IO_EXPANDER_PIN_NUM_0 | IO_EXPANDER_PIN_NUM_1|IO_EXPANDER_PIN_NUM_2, 1);
     esp_lcd_panel_reset(panel_handle);
     esp_lcd_panel_init(panel_handle);
     esp_lcd_panel_disp_on_off(panel_handle, true);

--- a/bsp/esp32_s3_touch_amoled_1_8/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_1_8/idf_component.yml
@@ -20,4 +20,4 @@ tags:
 targets:
 - esp32s3
 url: https://www.waveshare.com/esp32-s3-touch-amoled-1.8.htm
-version: 1.1.2
+version: 1.1.3


### PR DESCRIPTION
We suggest that the IO expansion part should be initialized externally and controlled.