### PR TITLE
ESP32-S3-Touch-AMOLED-2.06: Set max_transfer_sz from bsp_display_config_t

### DIFF
--- a/bsp/esp32_s3_touch_amoled_2_06/esp32_s3_touch_amoled_2_06.c
+++ b/bsp/esp32_s3_touch_amoled_2_06/esp32_s3_touch_amoled_2_06.c
@@ -423,6 +423,7 @@ static void bsp_lvgl_rounder_cb(lv_disp_drv_t *disp_drv, lv_area_t *area)
 esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
 {
     esp_err_t ret = ESP_OK;
+    assert(config != NULL && config->max_transfer_sz > 0);
 
     ESP_LOGI(TAG, "Initialize SPI bus");
     const spi_bus_config_t buscfg = SH8601_PANEL_BUS_QSPI_CONFIG(BSP_LCD_PCLK,
@@ -430,7 +431,7 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
                                                                  BSP_LCD_DATA1,
                                                                  BSP_LCD_DATA2,
                                                                  BSP_LCD_DATA3,
-                                                                 BSP_LCD_H_RES * BSP_LCD_V_RES * BSP_LCD_BITS_PER_PIXEL / 8);
+                                                                 config->max_transfer_sz);
     ESP_ERROR_CHECK(spi_bus_initialize(BSP_LCD_SPI_NUM, &buscfg, SPI_DMA_CH_AUTO));
 
     const esp_lcd_panel_io_spi_config_t io_config = SH8601_PANEL_IO_QSPI_CONFIG(BSP_LCD_CS, NULL, NULL);
@@ -496,7 +497,9 @@ esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t
 
 static lv_display_t *bsp_display_lcd_init()
 {
-    bsp_display_config_t disp_config = {0};
+    const bsp_display_config_t disp_config = {
+        .max_transfer_sz = BSP_LCD_H_RES * BSP_LCD_V_RES * BSP_LCD_BITS_PER_PIXEL / 8,
+    };
 
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&disp_config, &panel_handle, &io_handle));
 

--- a/bsp/esp32_s3_touch_amoled_2_06/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_2_06/idf_component.yml
@@ -16,4 +16,4 @@ tags:
 targets:
 - esp32s3
 url: https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm
-version: 1.0.5
+version: 1.0.6


### PR DESCRIPTION
This change allows bsp_display_new() API user to adjust SPI transfer buffer size which is required when fine tuning partial buffering.

LVGL v9 tested.