### PR TITLE
bsp: handle CST9217 invalid response correctly in LVGL 9 touch indev

### DIFF
--- a/bsp/esp32_s3_touch_amoled_1_75/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_1_75/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   esp_codec_dev:
-    version: "^1.3.3"
+    version: "^1.5.4"
     public: true
   waveshare/esp_lcd_sh8601: "*"
   waveshare/esp_lcd_touch_cst9217: "*"


### PR DESCRIPTION
The ESP32-S3-Touch-AMOLED-1.75 BSP would reboot continuously when using LVGL 9 because esp_lcd_touch_read_data() returns ESP_ERR_INVALID_RESPONSE while the CST9217 panel is not being touched. This caused lvgl_port_touchpad_read() to abort due to ESP_ERROR_CHECK(), even though the condition is expected and harmless.

This commit fixes the issue by:
- Providing a custom LVGL 9 touch read callback
- Explicitly storing the esp_lcd_touch handle using lv_indev_set_driver_data()
- Treating ESP_ERR_INVALID_RESPONSE as a released (no-touch) state instead of a fatal error

This prevents unnecessary aborts, avoids serial log spam, and restores stable operation without requiring changes to esp_lvgl_port internals. LVGL 8 behavior is preserved for backward compatibility.

Fixes #118