### PR TITLE
Minor logic correction to bsp_display_lock

### DIFF
--- a/bsp/esp32_s3_touch_amoled_1_75/esp32_s3_touch_amoled_1_75.c
+++ b/bsp/esp32_s3_touch_amoled_1_75/esp32_s3_touch_amoled_1_75.c
@@ -652,7 +652,7 @@ esp_err_t bsp_display_rotation_set(bsp_display_rotation_t rotation)
 
 bool bsp_display_lock(uint32_t timeout_ms)
 {
-    return esp_lv_adapter_lock(timeout_ms);
+    return (esp_lv_adapter_lock(timeout_ms) == ESP_OK);
 }
 
 void bsp_display_unlock(void)

--- a/bsp/esp32_s3_touch_amoled_1_75/include/bsp/esp32_s3_touch_amoled_1_75.h
+++ b/bsp/esp32_s3_touch_amoled_1_75/include/bsp/esp32_s3_touch_amoled_1_75.h
@@ -305,7 +305,7 @@ lv_indev_t *bsp_display_get_input_dev(void);
 /**
  * @brief Take LVGL mutex
  *
- * @param timeout_ms Timeout in [ms]. 0 will block indefinitely.
+ * @param timeout_ms Timeout in [ms]. -1 will block indefinitely.
  * @return true  Mutex was taken
  * @return false Mutex was NOT taken
  */


### PR DESCRIPTION
`bsp_display_lock` currently returns false when using lv_adapter despite successfully capturing the mutex. 
Proposed update to the return statement so that it only returns true when the mutex is successfully taken (as per the header file function description).

Also blocking behaviour should only happen with values below 0 for the time out, 0 itself excluded.