### PR TITLE
fix: Include Missing Headers

### DIFF
--- a/bsp/esp32_s3_touch_amoled_1_75/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_1_75/idf_component.yml
@@ -1,4 +1,4 @@
-version: 2.0.5
+version: 2.0.6
 description: Board Support Package (BSP) for Waveshare ESP32-S3-Touch-AMOLED-1.75
 url: https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm
 

--- a/bsp/esp32_s3_touch_amoled_1_75/include/bsp/display.h
+++ b/bsp/esp32_s3_touch_amoled_1_75/include/bsp/display.h
@@ -2,6 +2,7 @@
 
 #pragma once
 #include "esp_lcd_types.h"
+#include "esp_err.h"
 
 /* LCD color formats */
 #define ESP_LCD_COLOR_FORMAT_RGB565    (1)


### PR DESCRIPTION
This fixes a clang-tidy complaint about the non-included `esp_err_t` type.

```
managed_components/waveshare__esp32_s3_touch_amoled_1_75/include/bsp/display.h:64:1: error: unknown type name 'esp_err_t' [clang-diagnostic-error]
   64 | esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
      | ^
managed_components/waveshare__esp32_s3_touch_amoled_1_75/include/bsp/display.h:75:1: error: unknown type name 'esp_err_t' [clang-diagnostic-error]
   75 | esp_err_t bsp_display_brightness_init(void);
      | ^
managed_components/waveshare__esp32_s3_touch_amoled_1_75/include/bsp/display.h:77:1: error: unknown type name 'esp_err_t' [clang-diagnostic-error]
   77 | esp_err_t bsp_display_rotation_set(bsp_display_rotation_t rotation);
      | ^
managed_components/waveshare__esp32_s3_touch_amoled_1_75/include/bsp/display.h:90:1: error: unknown type name 'esp_err_t' [clang-diagnostic-error]
   90 | esp_err_t bsp_display_brightness_set(int brightness_percent);
      | ^
managed_components/waveshare__esp32_s3_touch_amoled_1_75/include/bsp/display.h:104:1: error: unknown type name 'esp_err_t' [clang-diagnostic-error]
  104 | esp_err_t bsp_display_backlight_on(void);
      | ^
managed_components/waveshare__esp32_s3_touch_amoled_1_75/include/bsp/display.h:116:1: error: unknown type name 'esp_err_t' [clang-diagnostic-error]
  116 | esp_err_t bsp_display_backlight_off(void);
      | ^

```