### PR TITLE
lcd: Release the i2c bus in all cases

### DIFF
--- a/display/lcd/esp_lcd_dsi/esp_lcd_dsi.c
+++ b/display/lcd/esp_lcd_dsi/esp_lcd_dsi.c
@@ -112,7 +112,7 @@ esp_err_t esp_lcd_new_panel_dsi(const esp_lcd_panel_io_handle_t io, const esp_lc
     i2c_bus_write_bytes(i2c0_device1, 0xad, 1, &data);
 
     i2c_bus_device_delete(&i2c0_device1);
-//    i2c_bus_delete(&i2c0_bus);
+    i2c_bus_delete(&i2c0_bus);
 
     vTaskDelay(pdMS_TO_TICKS(1000));
 

--- a/display/lcd/esp_lcd_hx8394/esp_lcd_hx8394.c
+++ b/display/lcd/esp_lcd_hx8394/esp_lcd_hx8394.c
@@ -128,7 +128,7 @@ esp_err_t esp_lcd_new_panel_hx8394(const esp_lcd_panel_io_handle_t io, const esp
     i2c_bus_write_bytes(i2c0_device1, 0x96, 1, &data);
 
     i2c_bus_device_delete(&i2c0_device1);
-    // i2c_bus_delete(&i2c0_bus);
+    i2c_bus_delete(&i2c0_bus);
 
     vTaskDelay(pdMS_TO_TICKS(1000));
 

--- a/display/lcd/esp_lcd_ili9881c/esp_lcd_ili9881c.c
+++ b/display/lcd/esp_lcd_ili9881c/esp_lcd_ili9881c.c
@@ -145,7 +145,7 @@ esp_err_t esp_lcd_new_panel_ili9881c(const esp_lcd_panel_io_handle_t io, const e
     i2c_bus_write_bytes(i2c0_device1, 0x96, 1, &data);
 
     i2c_bus_device_delete(&i2c0_device1);
-    // i2c_bus_delete(&i2c0_bus);
+    i2c_bus_delete(&i2c0_bus);
 
     vTaskDelay(pdMS_TO_TICKS(1000));
 

--- a/display/lcd/esp_lcd_jd9365/esp_lcd_jd9365.c
+++ b/display/lcd/esp_lcd_jd9365/esp_lcd_jd9365.c
@@ -141,7 +141,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
     i2c_bus_write_bytes(i2c0_device1, 0x96, 1, &data);
 
     i2c_bus_device_delete(&i2c0_device1);
-    // i2c_bus_delete(&i2c0_bus);
+    i2c_bus_delete(&i2c0_bus);
 
     vTaskDelay(pdMS_TO_TICKS(1000));
 

--- a/display/lcd/esp_lcd_jd9365_10_1/esp_lcd_jd9365_10_1.c
+++ b/display/lcd/esp_lcd_jd9365_10_1/esp_lcd_jd9365_10_1.c
@@ -144,7 +144,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
     i2c_bus_write_bytes(i2c0_device1, 0x96, 1, &data);
 
     i2c_bus_device_delete(&i2c0_device1);
-    // i2c_bus_delete(&i2c0_bus);
+    i2c_bus_delete(&i2c0_bus);
 
     vTaskDelay(pdMS_TO_TICKS(1000));
 

--- a/display/lcd/esp_lcd_jd9365_8/esp_lcd_jd9365_8.c
+++ b/display/lcd/esp_lcd_jd9365_8/esp_lcd_jd9365_8.c
@@ -144,7 +144,7 @@ esp_err_t esp_lcd_new_panel_jd9365_8(const esp_lcd_panel_io_handle_t io, const e
     i2c_bus_write_bytes(i2c0_device1, 0x96, 1, &data);
 
     i2c_bus_device_delete(&i2c0_device1);
-    // i2c_bus_delete(&i2c0_bus);
+    i2c_bus_delete(&i2c0_bus);
 
     vTaskDelay(pdMS_TO_TICKS(1000));
 

--- a/display/lcd/esp_lcd_ota7290b/esp_lcd_ota7290b.c
+++ b/display/lcd/esp_lcd_ota7290b/esp_lcd_ota7290b.c
@@ -106,7 +106,7 @@ esp_err_t esp_lcd_new_panel_ota7290b(const esp_lcd_panel_io_handle_t io, const e
     i2c_bus_write_bytes(i2c0_device1, 0x96, 1, &data);
 
     i2c_bus_device_delete(&i2c0_device1);
-    // i2c_bus_delete(&i2c0_bus);
+    i2c_bus_delete(&i2c0_bus);
 
     vTaskDelay(pdMS_TO_TICKS(1000));
 


### PR DESCRIPTION
The i2c bus needs to be released or otherwise it cannot be used by the application afterwards. Remove the comment from the line i2c_bus_delete which it was written to solve this problem in the first place. I am guessing that the comment in this line was just forgotten.