### PR TITLE
fix(bsp): add missing #include <string.h> in esp32_p4_wifi6_touch_lcd_7b.c

### DIFF
--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
@@ -8,6 +8,7 @@
 #include "driver/gpio.h"
 #include "driver/ledc.h"
 #include "esp_err.h"
+#include <string.h>
 #include "esp_log.h"
 #include "esp_check.h"
 #include "esp_spiffs.h"


### PR DESCRIPTION
## Problem

`esp32_p4_wifi6_touch_lcd_7b.c` calls `memcpy()` (lines 518 and 523) without including `<string.h>`.

On older ESP-IDF versions this compiles because `string.h` is transitively pulled in by other headers. On **ESP-IDF v5.4.4** (and likely any version with stricter implicit-declaration warnings), the build fails:

```
error: implicit declaration of function 'memcpy' [-Werror=implicit-function-declaration]
```

## Fix

Add `#include <string.h>` alongside the existing includes.

## Testing

- Verified the project compiles cleanly with `idf.py build` targeting esp32p4 on ESP-IDF v5.4.4 after this change.