### PR TITLE
Add esp_driver_i2c requirement to qmi8658 component

### DIFF
--- a/sensor/qmi8658/CMakeLists.txt
+++ b/sensor/qmi8658/CMakeLists.txt
@@ -1,1 +1,1 @@
-idf_component_register(SRCS "qmi8658.c" INCLUDE_DIRS "include" REQUIRES "driver")
+idf_component_register(SRCS "qmi8658.c" INCLUDE_DIRS "include" REQUIRES "driver" "esp_driver_i2c")


### PR DESCRIPTION
This fixes #158 . It's required for current versions of ESP-IDF.