### PR TITLE
Guard ESP32-P4 Nano rev3-only LCDs

### DIFF
--- a/bsp/esp32_p4_nano/CMakeLists.txt
+++ b/bsp/esp32_p4_nano/CMakeLists.txt
@@ -4,5 +4,5 @@ idf_component_register(
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
     REQUIRES driver
-    PRIV_REQUIRES esp_lcd usb spiffs fatfs
+    PRIV_REQUIRES esp_lcd usb spiffs fatfs hal
 )

--- a/bsp/esp32_p4_nano/Kconfig
+++ b/bsp/esp32_p4_nano/Kconfig
@@ -5,7 +5,7 @@ menu "Board Support Package(ESP32-P4)"
         default y
         help
             Error check assert the application before returning the error code.
-            
+
     menu "I2C"
         config BSP_I2C_NUM
             int "I2C peripheral index"
@@ -82,14 +82,16 @@ menu "Board Support Package(ESP32-P4)"
             default 1
             range 1 3
             help
-                Let DPI LCD driver create a specified number of frame-size buffers. Only when it is set to multiple can the avoiding tearing be turned on.
+                Let DPI LCD driver create a specified number of frame-size buffers.
+                Only when it is set to multiple can the avoiding tearing be turned on.
 
         config BSP_DISPLAY_LVGL_AVOID_TEAR
             bool "Avoid tearing effect"
             depends on BSP_LCD_DPI_BUFFER_NUMS > 1
             default "n"
             help
-                Avoid tearing effect through LVGL buffer mode and double frame buffers of RGB LCD. This feature is only available for RGB LCD.
+                Avoid tearing effect through LVGL buffer mode and double frame buffers
+                of RGB LCD. This feature is only available for RGB LCD.
 
         choice BSP_DISPLAY_LVGL_MODE
             depends on BSP_DISPLAY_LVGL_AVOID_TEAR
@@ -100,14 +102,14 @@ menu "Board Support Package(ESP32-P4)"
             config BSP_DISPLAY_LVGL_DIRECT_MODE
                 bool "Direct mode"
         endchoice
-            
+
         config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
-        int "LEDC channel index"
-        default 1
-        range 0 7
-        help
-            LEDC channel is used to generate PWM signal that controls display brightness.
-            Set LEDC index that should be used.
+            int "LEDC channel index"
+            default 1
+            range 0 7
+            help
+                LEDC channel is used to generate PWM signal that controls display brightness.
+                Set LEDC index that should be used.
 
         choice BSP_LCD_COLOR_FORMAT
             prompt "Select LCD color format"
@@ -119,16 +121,20 @@ menu "Board Support Package(ESP32-P4)"
                 bool "RGB565"
             config BSP_LCD_COLOR_FORMAT_RGB888
                 bool "RGB888"
-        endchoice   
-            
+        endchoice
+
         choice BSP_LCD_TYPE
             prompt "Select LCD type"
-            default BSP_LCD_TYPE_800_1280_10_1_INCH
+            default BSP_LCD_TYPE_800_1280_10_1_INCH if ESP_REV_MIN_FULL >= 300
+            default BSP_LCD_TYPE_800_1280_10_1_INCH_A
             help
-                Select the LCD.
+                Select the LCD. DSI-TOUCH-A/B displays match the esp32_p4_platform
+                compatibility list and support ESP32-P4 rev v1.3 and rev v3.x.
+                Displays marked "ESP32-P4 rev 3.x only" require ESP32-P4 rev v3.0
+                or later hardware and CONFIG_ESP_REV_MIN_FULL=300 or higher.
 
             config BSP_LCD_TYPE_800_1280_10_1_INCH
-                bool "Waveshare 101M-8001280-IPS-CT-K Display"
+                bool "Waveshare 101M-8001280-IPS-CT-K Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_800_1280_10_1_INCH_A
                 bool "Waveshare 10.1-DSI-TOUCH-A Display"
             config BSP_LCD_TYPE_800_1280_8_INCH_A
@@ -142,45 +148,66 @@ menu "Board Support Package(ESP32-P4)"
             config BSP_LCD_TYPE_720_1280_9_INCH_B
                 bool "Waveshare 9-DSI-TOUCH-B Display"
             config BSP_LCD_TYPE_480_640_2_8_INCH
-                bool "Waveshare 2.8inch DSI LCD Display"
+                bool "Waveshare 2.8inch DSI LCD Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_800_800_3_4_INCH_C
-                bool "Waveshare 3.4inch DSI LCD (C) Display"
+                bool "Waveshare 3.4inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_720_720_4_INCH_C
-                bool "Waveshare 4inch DSI LCD (C) Display"
+                bool "Waveshare 4inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_480_800_4_INCH
-                bool "Waveshare 4inch DSI LCD Display"
+                bool "Waveshare 4inch DSI LCD Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_720_1280_5_INCH_D
-                bool "Waveshare 5inch DSI LCD (D) Display"
+                bool "Waveshare 5inch DSI LCD (D) Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_720_1560_6_25_INCH
-                bool "Waveshare 6.25inch DSI LCD Display"
+                bool "Waveshare 6.25inch DSI LCD Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_1024_600_5_INCH_C
-                bool "Waveshare 5inch DSI LCD (C) Display"
+                bool "Waveshare 5inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_1024_600_7_INCH_C
-                bool "Waveshare 7inch DSI LCD (C) Display"
+                bool "Waveshare 7inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_400_1280_7_9_INCH
-                bool "Waveshare 7.9inch DSI LCD Display"
+                bool "Waveshare 7.9inch DSI LCD Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_1280_800_7_INCH_E
-                bool "Waveshare 7inch DSI LCD (E) Display"
+                bool "Waveshare 7inch DSI LCD (E) Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_1280_800_8_INCH_C
-                bool "Waveshare 8inch DSI LCD (C) Display"
+                bool "Waveshare 8inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_1280_800_10_1_INCH_C
-                bool "Waveshare 10.1inch DSI LCD (C) Display"
+                bool "Waveshare 10.1inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_480_1920_8_8_INCH
-                bool "Waveshare 8.8inch DSI LCD Display"
+                bool "Waveshare 8.8inch DSI LCD Display (ESP32-P4 rev 3.x only)"
             config BSP_LCD_TYPE_320_1480_11_9_INCH
-                bool "Waveshare 11.9inch DSI LCD Display"
+                bool "Waveshare 11.9inch DSI LCD Display (ESP32-P4 rev 3.x only)"
         endchoice
 
-        config BSP_LCD_MIPI_DSI_LANE_BITRATE_MBPS
-        int "MIPI DSI lane bitrate (Mbps)"
-        default 1500
-        range 600 1500
-        help
-            Set the lane bitrate for the MIPI DSI interface in Mbps.
-            Adjust this value based on the display's requirements and capabilities.
-            Try 840, 860, 933, 1000, 1200, 1500.
+        config BSP_LCD_REQUIRES_ESP32P4_REV3
+            bool
+            default y if BSP_LCD_TYPE_800_1280_10_1_INCH
+            default y if BSP_LCD_TYPE_480_640_2_8_INCH
+            default y if BSP_LCD_TYPE_800_800_3_4_INCH_C
+            default y if BSP_LCD_TYPE_720_720_4_INCH_C
+            default y if BSP_LCD_TYPE_480_800_4_INCH
+            default y if BSP_LCD_TYPE_720_1280_5_INCH_D
+            default y if BSP_LCD_TYPE_720_1560_6_25_INCH
+            default y if BSP_LCD_TYPE_1024_600_5_INCH_C
+            default y if BSP_LCD_TYPE_1024_600_7_INCH_C
+            default y if BSP_LCD_TYPE_400_1280_7_9_INCH
+            default y if BSP_LCD_TYPE_1280_800_7_INCH_E
+            default y if BSP_LCD_TYPE_1280_800_8_INCH_C
+            default y if BSP_LCD_TYPE_1280_800_10_1_INCH_C
+            default y if BSP_LCD_TYPE_480_1920_8_8_INCH
+            default y if BSP_LCD_TYPE_320_1480_11_9_INCH
+            default n
+            help
+                Internal flag for LCD selections that require ESP32-P4 chip
+                revision v3.0 or later.
 
-        
+        config BSP_LCD_MIPI_DSI_LANE_BITRATE_MBPS
+            int "MIPI DSI lane bitrate (Mbps)"
+            default 1500
+            range 600 1500
+            help
+                Set the lane bitrate for the MIPI DSI interface in Mbps.
+                Adjust this value based on the display's requirements and capabilities.
+                Try 840, 860, 933, 1000, 1200, 1500.
+
     endmenu
-    
+
 endmenu

--- a/bsp/esp32_p4_nano/README.md
+++ b/bsp/esp32_p4_nano/README.md
@@ -12,27 +12,27 @@ ESP32-P4-NANO is a small size and highly integrated development board designed b
 Configuration in `menuconfig`.
 
 Selection LCD display `Board Support Package(ESP32-P4) --> Display --> Select LCD type`
-- Waveshare 101M-8001280-IPS-CT-K Display (default)
+- Waveshare 101M-8001280-IPS-CT-K Display (default only when ESP32-P4 minimum chip revision is v3.0 or later; ESP32-P4 rev 3.x only)
 - Waveshare 10.1-DSI-TOUCH-A Display 
 - Waveshare 8-DSI-TOUCH-A Display
 - Waveshare 7-DSI-TOUCH-A Display
 - Waveshare 5-DSI-Touch-A Display
 - Waveshare 10.1-DSI-Touch-B Display
 - Waveshare 9-DSI-Touch-B Display
-- Waveshare 2.8inch DSI LCD Display
-- Waveshare 3.4inch DSI LCD (C) Display
-- Waveshare 4inch DSI LCD (C) Display
-- Waveshare 4inch DSI LCD Display
-- Waveshare 5inch DSI LCD (D) Display
-- Waveshare 6.25inch DSI LCD Display
-- Waveshare 5inch DSI LCD (C) Display
-- Waveshare 7inch DSI LCD (C) Display
-- Waveshare 7.9inch DSI LCD Display
-- Waveshare 7inch DSI LCD (E) Display
-- Waveshare 8inch DSI LCD (C) Display
-- Waveshare 10.1inch DSI LCD (C) Display
-- Waveshare 8.8inch DSI LCD Display
-- Waveshare 11.9inch DSI LCD Display
+- Waveshare 2.8inch DSI LCD Display (ESP32-P4 rev 3.x only)
+- Waveshare 3.4inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)
+- Waveshare 4inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)
+- Waveshare 4inch DSI LCD Display (ESP32-P4 rev 3.x only)
+- Waveshare 5inch DSI LCD (D) Display (ESP32-P4 rev 3.x only)
+- Waveshare 6.25inch DSI LCD Display (ESP32-P4 rev 3.x only)
+- Waveshare 5inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)
+- Waveshare 7inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)
+- Waveshare 7.9inch DSI LCD Display (ESP32-P4 rev 3.x only)
+- Waveshare 7inch DSI LCD (E) Display (ESP32-P4 rev 3.x only)
+- Waveshare 8inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)
+- Waveshare 10.1inch DSI LCD (C) Display (ESP32-P4 rev 3.x only)
+- Waveshare 8.8inch DSI LCD Display (ESP32-P4 rev 3.x only)
+- Waveshare 11.9inch DSI LCD Display (ESP32-P4 rev 3.x only)
 
 Selection color format `Board Support Package(ESP32-P4) --> Display --> Select LCD color format`
 - RGB565 (default)
@@ -41,20 +41,29 @@ Selection color format `Board Support Package(ESP32-P4) --> Display --> Select L
 Change MIPI DSI lane bitrate `Board Support Package(ESP32-P4) --> Display --> MIPI DSI lane bitrate (Mbps)`
 - 1500 (default)
 
+## ESP32-P4 chip revision compatibility
+
+The DSI-TOUCH-A/B displays shared with `esp32_p4_platform` support ESP32-P4 chip rev v1.3 and rev v3.x. The additional Raspberry Pi adapter displays in this BSP, and the 101M-8001280-IPS-CT-K display, require ESP32-P4 chip rev v3.0 or later.
+
+When selecting an ESP32-P4 rev 3.x-only display:
+- Use ESP32-P4 rev v3.0 or later hardware. Rev v1.3 hardware is not supported for these LCDs.
+- Set the ESP-IDF minimum chip revision to v3.0 before building (`CONFIG_ESP_REV_MIN_FULL=300` or higher).
+- The BSP emits a build error when a rev 3.x-only display is selected with a lower minimum revision, and `bsp_display_new*()` / `bsp_touch_new()` return `ESP_ERR_NOT_SUPPORTED` if the runtime eFuse chip revision is lower than v3.0.
+
 ## Display Page
 
 
 ### Recommended display screen
 
-| Product ID                                                                                                                                                                                                                                                                                               | Dependency                                                            | tested |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|--------|
-| [10.1-DSI-TOUCH-A](https://www.waveshare.com/10.1-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/0/10.1-dsi-touch-a-1.jpg">                | [~~waveshare/esp_lcd_jd9365_10_1~~](display/lcd/esp_lcd_jd9365_10_1)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365) | ✅      |
-| [101M-8001280-IPS-CT-K](https://www.waveshare.com/101m-8001280-ips-ct-k.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/0/101m-8001280-ips-ct-k-1.jpg"> | [~~waveshare/esp_lcd_jd9365_10_1~~](display/lcd/esp_lcd_jd9365_10_1)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)      | ✅      |
-| [8-DSI-TOUCH-A](https://www.waveshare.com/8-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/-/8-dsi-touch-a-1.jpg">                         | [~~waveshare/esp_lcd_jd9365_8~~](display/lcd/esp_lcd_ili9881c)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)            | ✅      |
-| [7-DSI-TOUCH-A](https://www.waveshare.com/7-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/7/-/7-dsi-touch-a-1.jpg">                         | [waveshare/esp_lcd_ili9881c](display/lcd/esp_lcd_ili9881c)            | ✅      |
-| [5-DSI-TOUCH-A](https://www.waveshare.com/5-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/5/-/5-dsi-touch-a-1_1.jpg">                       | [waveshare/esp_lcd_hx8394](display/lcd/esp_lcd_hx8394)                | ✅      |
-| [10.1-DSI-TOUCH-B](https://www.waveshare.com/10.1-dsi-touch-b.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/-/8-dsi-touch-a-1.jpg">                 | [waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)                | ✅      |
-| [9-DSI-TOUCH-B](https://www.waveshare.com/9-dsi-touch-b.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/-/8-dsi-touch-a-1.jpg">                       | [waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)                | ✅      |
+| Product ID                                                                                                                                                                                                                                                                                               | Dependency                                                            | ESP32-P4 chip rev | tested |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|-------------------|--------|
+| [10.1-DSI-TOUCH-A](https://www.waveshare.com/10.1-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/0/10.1-dsi-touch-a-1.jpg">                | [~~waveshare/esp_lcd_jd9365_10_1~~](display/lcd/esp_lcd_jd9365_10_1)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365) | v1.3 / v3.x       | ✅      |
+| [101M-8001280-IPS-CT-K](https://www.waveshare.com/101m-8001280-ips-ct-k.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/0/101m-8001280-ips-ct-k-1.jpg"> | [~~waveshare/esp_lcd_jd9365_10_1~~](display/lcd/esp_lcd_jd9365_10_1)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)      | v3.x only         | ✅      |
+| [8-DSI-TOUCH-A](https://www.waveshare.com/8-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/-/8-dsi-touch-a-1.jpg">                         | [~~waveshare/esp_lcd_jd9365_8~~](display/lcd/esp_lcd_ili9881c)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)            | v1.3 / v3.x       | ✅      |
+| [7-DSI-TOUCH-A](https://www.waveshare.com/7-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/7/-/7-dsi-touch-a-1.jpg">                         | [waveshare/esp_lcd_ili9881c](display/lcd/esp_lcd_ili9881c)            | v1.3 / v3.x       | ✅      |
+| [5-DSI-TOUCH-A](https://www.waveshare.com/5-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/5/-/5-dsi-touch-a-1_1.jpg">                       | [waveshare/esp_lcd_hx8394](display/lcd/esp_lcd_hx8394)                | v1.3 / v3.x       | ✅      |
+| [10.1-DSI-TOUCH-B](https://www.waveshare.com/10.1-dsi-touch-b.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/-/8-dsi-touch-a-1.jpg">                 | [waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)                | v1.3 / v3.x       | ✅      |
+| [9-DSI-TOUCH-B](https://www.waveshare.com/9-dsi-touch-b.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/-/8-dsi-touch-a-1.jpg">                       | [waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)                | v1.3 / v3.x       | ✅      |
 
 ### Common Raspberry adapter screen
 
@@ -62,22 +71,22 @@ Change MIPI DSI lane bitrate `Board Support Package(ESP32-P4) --> Display --> MI
 <details open>
 <summary>View full display</summary>
 
-| Product ID                                                                                                                                                                                                                                                                                               | Dependency                                                       | tested |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|--------|
-| [2.8inch DSI LCD](https://www.waveshare.com/2.8inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/thumbnail/122x122/9df78eab33525d08d6e5fb8d27136e95/2/_/2.8inch-dsi-lcd-3.jpg">               | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [3.4inch DSI LCD (C)](https://www.waveshare.com/3.4inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/3/_/3.4inch-dsi-lcd-c-1.jpg">           | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [4inch DSI LCD (C)](https://www.waveshare.com/4inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/4/i/4inch-dsi-lcd-c-1.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [4inch DSI LCD](https://www.waveshare.com/4inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/4/i/4inch-dsi-lcd-1.jpg">                         | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [5inch DSI LCD (D)](https://www.waveshare.com/5inch-dsi-lcd-d.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/5/i/5inch-dsi-lcd-d-2.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [6.25inch DSI LCD](https://www.waveshare.com/6.25inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/6/_/6.25inch-dsi-lcd-2.jpg">                | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [5inch DSI LCD (C)](https://www.waveshare.com/5inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/5/i/5inch-dsi-lcd-c-2.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [7inch DSI LCD (C)](https://www.waveshare.com/7inch-dsi-lcd-c-with-case-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/7/i/7inch-dsi-lcd-c-4.jpg">     | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [7.9inch DSI LCD](https://www.waveshare.com/7.9inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/7/_/7.9inch-dsi-lcd-2.jpg">                   | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [7inch DSI LCD (E)](https://www.waveshare.com/7inch-dsi-lcd-e.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/7/i/7inch-dsi-lcd-e-2.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [8inch DSI LCD (C)](https://www.waveshare.com/8inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/i/8inch-dsi-lcd-c-2.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [10.1inch DSI LCD (C)](https://www.waveshare.com/10.1inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/0/10.1inch-dsi-lcd-c-2.jpg">        | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [8.8inch DSI LCD](https://www.waveshare.com/8.8inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/_/8.8inch-dsi-lcd-2.jpg">                   | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
-| [11.9inch DSI LCD](https://www.waveshare.com/11.9inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/1/11.9inch-dsi-lcd-3.jpg">                | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | ✅      |
+| Product ID                                                                                                                                                                                                                                                                                               | Dependency                                                       | ESP32-P4 chip rev | tested |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|-------------------|--------|
+| [2.8inch DSI LCD](https://www.waveshare.com/2.8inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/thumbnail/122x122/9df78eab33525d08d6e5fb8d27136e95/2/_/2.8inch-dsi-lcd-3.jpg">               | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [3.4inch DSI LCD (C)](https://www.waveshare.com/3.4inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/3/_/3.4inch-dsi-lcd-c-1.jpg">           | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [4inch DSI LCD (C)](https://www.waveshare.com/4inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/4/i/4inch-dsi-lcd-c-1.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [4inch DSI LCD](https://www.waveshare.com/4inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/4/i/4inch-dsi-lcd-1.jpg">                         | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [5inch DSI LCD (D)](https://www.waveshare.com/5inch-dsi-lcd-d.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/5/i/5inch-dsi-lcd-d-2.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [6.25inch DSI LCD](https://www.waveshare.com/6.25inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/6/_/6.25inch-dsi-lcd-2.jpg">                | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [5inch DSI LCD (C)](https://www.waveshare.com/5inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/5/i/5inch-dsi-lcd-c-2.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [7inch DSI LCD (C)](https://www.waveshare.com/7inch-dsi-lcd-c-with-case-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/7/i/7inch-dsi-lcd-c-4.jpg">     | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [7.9inch DSI LCD](https://www.waveshare.com/7.9inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/7/_/7.9inch-dsi-lcd-2.jpg">                   | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [7inch DSI LCD (E)](https://www.waveshare.com/7inch-dsi-lcd-e.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/7/i/7inch-dsi-lcd-e-2.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [8inch DSI LCD (C)](https://www.waveshare.com/8inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/i/8inch-dsi-lcd-c-2.jpg">                 | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [10.1inch DSI LCD (C)](https://www.waveshare.com/10.1inch-dsi-lcd-c.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/0/10.1inch-dsi-lcd-c-2.jpg">        | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [8.8inch DSI LCD](https://www.waveshare.com/8.8inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/_/8.8inch-dsi-lcd-2.jpg">                   | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
+| [11.9inch DSI LCD](https://www.waveshare.com/11.9inch-dsi-lcd.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/1/11.9inch-dsi-lcd-3.jpg">                | [waveshare/esp_lcd_dsi](display/lcd/esp_lcd_dsi)                 | v3.x only         | ✅      |
 </details>
 
 

--- a/bsp/esp32_p4_nano/esp32_p4_nano.c
+++ b/bsp/esp32_p4_nano/esp32_p4_nano.c
@@ -1,4 +1,5 @@
 #include "sdkconfig.h"
+#include <inttypes.h>
 #include "driver/gpio.h"
 #include "driver/ledc.h"
 #include "esp_err.h"
@@ -9,6 +10,7 @@
 #include "esp_lcd_mipi_dsi.h"
 #include "esp_ldo_regulator.h"
 #include "esp_vfs_fat.h"
+#include "hal/efuse_hal.h"
 #include "usb/usb_host.h"
 #include "sd_pwr_ctrl_by_on_chip_ldo.h"
 
@@ -44,6 +46,21 @@ static i2c_master_bus_handle_t i2c_handle = NULL;  // I2C Handle
 static i2s_chan_handle_t i2s_tx_chan = NULL;
 static i2s_chan_handle_t i2s_rx_chan = NULL;
 static const audio_codec_data_if_t *i2s_data_if = NULL;  /* Codec data interface */
+
+static esp_err_t bsp_lcd_check_chip_revision(void)
+{
+#if BSP_LCD_REQUIRES_ESP32P4_REV3
+    uint32_t chip_rev = efuse_hal_chip_revision();
+
+    if (chip_rev < BSP_ESP32P4_REV3_MIN_FULL) {
+        ESP_LOGE(TAG, "Selected LCD requires ESP32-P4 rev v3.0 or later, detected v%" PRIu32 ".%" PRIu32,
+                 chip_rev / 100, chip_rev % 100);
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+#endif
+
+    return ESP_OK;
+}
 
 /* Can be used for `i2s_std_gpio_config_t` and/or `i2s_std_config_t` initialization */
 #define BSP_I2S_GPIO_CFG       \
@@ -411,6 +428,7 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
 {
     esp_err_t ret = ESP_OK;
 
+    ESP_RETURN_ON_ERROR(bsp_lcd_check_chip_revision(), TAG, "LCD chip revision check failed");
     ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
     ESP_RETURN_ON_ERROR(bsp_enable_dsi_phy_power(), TAG, "DSI PHY power failed");
 
@@ -646,6 +664,8 @@ err:
 
 esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t *ret_touch)
 {
+    ESP_RETURN_ON_ERROR(bsp_lcd_check_chip_revision(), TAG, "LCD chip revision check failed");
+
     /* Initilize I2C */
     BSP_ERROR_CHECK_RETURN_ERR(bsp_i2c_init());
 

--- a/bsp/esp32_p4_nano/idf_component.yml
+++ b/bsp/esp32_p4_nano/idf_component.yml
@@ -25,4 +25,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-nano.htm
-version: 1.2.1
+version: 1.2.2

--- a/bsp/esp32_p4_nano/include/bsp/display.h
+++ b/bsp/esp32_p4_nano/include/bsp/display.h
@@ -3,6 +3,18 @@
 #include "esp_lcd_mipi_dsi.h"
 #include "sdkconfig.h"
 
+#define BSP_ESP32P4_REV3_MIN_FULL (300)
+
+#if CONFIG_BSP_LCD_REQUIRES_ESP32P4_REV3
+#define BSP_LCD_REQUIRES_ESP32P4_REV3 (1)
+#else
+#define BSP_LCD_REQUIRES_ESP32P4_REV3 (0)
+#endif
+
+#if BSP_LCD_REQUIRES_ESP32P4_REV3 && (CONFIG_ESP_REV_MIN_FULL < BSP_ESP32P4_REV3_MIN_FULL)
+#error "This LCD selection requires ESP32-P4 rev v3.0 or later. Set CONFIG_ESP_REV_MIN_FULL=300 or choose a rev v1.3-compatible LCD."
+#endif
+
 /* LCD color formats */
 #define ESP_LCD_COLOR_FORMAT_RGB565    (1)
 #define ESP_LCD_COLOR_FORMAT_RGB888    (2)


### PR DESCRIPTION
Summary:
- Mark ESP32-P4 Nano LCD selections that require rev v3.0 or later.
- Add build-time and runtime revision guards for rev3-only LCDs.
- Document chip revision compatibility in the BSP README.

Tests:
- ESP-IDF check_kconfigs.py bsp/esp32_p4_nano/Kconfig
- git diff --check for touched files

Note: Full idf.py build was not run because this repository has no esp32_p4_nano test app.