### PR TITLE
fix(bsp): update p4 nano 101m rev compatibility

### DIFF
--- a/bsp/esp32_p4_nano/Kconfig
+++ b/bsp/esp32_p4_nano/Kconfig
@@ -125,16 +125,18 @@ menu "Board Support Package(ESP32-P4)"
 
         choice BSP_LCD_TYPE
             prompt "Select LCD type"
-            default BSP_LCD_TYPE_800_1280_10_1_INCH if ESP_REV_MIN_FULL >= 300
-            default BSP_LCD_TYPE_800_1280_10_1_INCH_A
+            default BSP_LCD_TYPE_800_1280_10_1_INCH
             help
                 Select the LCD. DSI-TOUCH-A/B displays match the esp32_p4_platform
                 compatibility list and support ESP32-P4 rev v1.3 and rev v3.x.
+                The 101M-8001280-IPS-CT-K display is the predecessor of the
+                10.1-DSI-TOUCH-A display and also supports ESP32-P4 rev v1.3
+                and rev v3.x.
                 Displays marked "ESP32-P4 rev 3.x only" require ESP32-P4 rev v3.0
                 or later hardware and CONFIG_ESP_REV_MIN_FULL=300 or higher.
 
             config BSP_LCD_TYPE_800_1280_10_1_INCH
-                bool "Waveshare 101M-8001280-IPS-CT-K Display (ESP32-P4 rev 3.x only)"
+                bool "Waveshare 101M-8001280-IPS-CT-K Display"
             config BSP_LCD_TYPE_800_1280_10_1_INCH_A
                 bool "Waveshare 10.1-DSI-TOUCH-A Display"
             config BSP_LCD_TYPE_800_1280_8_INCH_A
@@ -179,7 +181,6 @@ menu "Board Support Package(ESP32-P4)"
 
         config BSP_LCD_REQUIRES_ESP32P4_REV3
             bool
-            default y if BSP_LCD_TYPE_800_1280_10_1_INCH
             default y if BSP_LCD_TYPE_480_640_2_8_INCH
             default y if BSP_LCD_TYPE_800_800_3_4_INCH_C
             default y if BSP_LCD_TYPE_720_720_4_INCH_C

--- a/bsp/esp32_p4_nano/README.md
+++ b/bsp/esp32_p4_nano/README.md
@@ -12,7 +12,7 @@ ESP32-P4-NANO is a small size and highly integrated development board designed b
 Configuration in `menuconfig`.
 
 Selection LCD display `Board Support Package(ESP32-P4) --> Display --> Select LCD type`
-- Waveshare 101M-8001280-IPS-CT-K Display (default only when ESP32-P4 minimum chip revision is v3.0 or later; ESP32-P4 rev 3.x only)
+- Waveshare 101M-8001280-IPS-CT-K Display
 - Waveshare 10.1-DSI-TOUCH-A Display 
 - Waveshare 8-DSI-TOUCH-A Display
 - Waveshare 7-DSI-TOUCH-A Display
@@ -43,7 +43,7 @@ Change MIPI DSI lane bitrate `Board Support Package(ESP32-P4) --> Display --> MI
 
 ## ESP32-P4 chip revision compatibility
 
-The DSI-TOUCH-A/B displays shared with `esp32_p4_platform` support ESP32-P4 chip rev v1.3 and rev v3.x. The additional Raspberry Pi adapter displays in this BSP, and the 101M-8001280-IPS-CT-K display, require ESP32-P4 chip rev v3.0 or later.
+The DSI-TOUCH-A/B displays shared with `esp32_p4_platform` support ESP32-P4 chip rev v1.3 and rev v3.x. The 101M-8001280-IPS-CT-K display is the predecessor of `10.1-DSI-TOUCH-A` and also supports ESP32-P4 chip rev v1.3 and rev v3.x. The additional Raspberry Pi adapter displays in this BSP require ESP32-P4 chip rev v3.0 or later.
 
 When selecting an ESP32-P4 rev 3.x-only display:
 - Use ESP32-P4 rev v3.0 or later hardware. Rev v1.3 hardware is not supported for these LCDs.
@@ -58,7 +58,7 @@ When selecting an ESP32-P4 rev 3.x-only display:
 | Product ID                                                                                                                                                                                                                                                                                               | Dependency                                                            | ESP32-P4 chip rev | tested |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|-------------------|--------|
 | [10.1-DSI-TOUCH-A](https://www.waveshare.com/10.1-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/0/10.1-dsi-touch-a-1.jpg">                | [~~waveshare/esp_lcd_jd9365_10_1~~](display/lcd/esp_lcd_jd9365_10_1)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365) | v1.3 / v3.x       | ✅      |
-| [101M-8001280-IPS-CT-K](https://www.waveshare.com/101m-8001280-ips-ct-k.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/0/101m-8001280-ips-ct-k-1.jpg"> | [~~waveshare/esp_lcd_jd9365_10_1~~](display/lcd/esp_lcd_jd9365_10_1)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)      | v3.x only         | ✅      |
+| [101M-8001280-IPS-CT-K](https://www.waveshare.com/101m-8001280-ips-ct-k.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/1/0/101m-8001280-ips-ct-k-1.jpg"> | [~~waveshare/esp_lcd_jd9365_10_1~~](display/lcd/esp_lcd_jd9365_10_1)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)      | v1.3 / v3.x       | ✅      |
 | [8-DSI-TOUCH-A](https://www.waveshare.com/8-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/8/-/8-dsi-touch-a-1.jpg">                         | [~~waveshare/esp_lcd_jd9365_8~~](display/lcd/esp_lcd_ili9881c)<br/>[waveshare/esp_lcd_jd9365](display/lcd/esp_lcd_jd9365)            | v1.3 / v3.x       | ✅      |
 | [7-DSI-TOUCH-A](https://www.waveshare.com/7-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/7/-/7-dsi-touch-a-1.jpg">                         | [waveshare/esp_lcd_ili9881c](display/lcd/esp_lcd_ili9881c)            | v1.3 / v3.x       | ✅      |
 | [5-DSI-TOUCH-A](https://www.waveshare.com/5-dsi-touch-a.htm) <br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/5/-/5-dsi-touch-a-1_1.jpg">                       | [waveshare/esp_lcd_hx8394](display/lcd/esp_lcd_hx8394)                | v1.3 / v3.x       | ✅      |

--- a/bsp/esp32_p4_nano/idf_component.yml
+++ b/bsp/esp32_p4_nano/idf_component.yml
@@ -25,4 +25,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-nano.htm
-version: 1.2.2
+version: 1.2.3


### PR DESCRIPTION
Summary:
- Treat 101M-8001280-IPS-CT-K as compatible with ESP32-P4 rev v1.3 and rev v3.x.
- Remove 101M from the rev v3.0+ LCD guard while keeping Raspberry Pi adapter displays guarded.
- Bump esp32_p4_nano component version to 1.2.3.

Validation:
- Kconfig check passed for bsp/esp32_p4_nano/Kconfig.
- git diff --check passed for the modified esp32_p4_nano files.
- GitHub checks passed: manifest-check and build-changed-components (bsp/esp32_p4_nano).