### PR TITLE
fix(bsp): add ESP-IDF v6 compatibility checks

### DIFF
--- a/.github/scripts/build_changed_component.py
+++ b/.github/scripts/build_changed_component.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 REPO = Path.cwd()
 DEFAULT_TARGET = "esp32s3"
+LOCAL_COMPONENT_ROOTS = ("display/lcd", "display/oled", "display/touch", "sensor", "lora")
 
 
 def idf_command():
@@ -51,6 +52,48 @@ def component_targets(component_dir):
     return targets or [DEFAULT_TARGET]
 
 
+def component_dependencies(component_dir):
+    manifest = component_dir / "idf_component.yml"
+    lines = manifest.read_text(encoding="utf-8").splitlines()
+    dependencies = []
+    for line_number, line in enumerate(lines):
+        if line.strip() != "dependencies:" or line.startswith((" ", "\t")):
+            continue
+        for child in lines[line_number + 1:]:
+            child_stripped = child.strip()
+            if not child_stripped or child_stripped.startswith("#"):
+                continue
+            if not child.startswith((" ", "\t")):
+                break
+            if child.startswith("  ") and not child.startswith("    ") and ":" in child_stripped:
+                dependencies.append(child_stripped.split(":", 1)[0])
+        break
+    return dependencies
+
+
+def local_component_index():
+    index = {}
+    for root in LOCAL_COMPONENT_ROOTS:
+        root_path = REPO / root
+        if not root_path.exists():
+            continue
+        for manifest in root_path.glob("*/idf_component.yml"):
+            component_dir = manifest.parent
+            component_name = component_dir.name
+            for key in (component_name, f"waveshare/{component_name}", f"espressif/{component_name}"):
+                index.setdefault(key, component_dir)
+    return index
+
+
+def local_dependency_overrides(component_dir):
+    index = local_component_index()
+    overrides = {}
+    for dependency in component_dependencies(component_dir):
+        if dependency in index:
+            overrides[dependency] = index[dependency]
+    return overrides
+
+
 def candidate_projects(component_dir):
     projects = []
     for name in ("test_app", "test_apps"):
@@ -66,10 +109,18 @@ def write_generated_project(component_dir, component_slug):
     if project_dir.exists():
         shutil.rmtree(project_dir)
     (project_dir / "main").mkdir(parents=True)
+    extra_component_dirs = [component_dir.resolve()]
+    local_overrides = local_dependency_overrides(component_dir)
+    for dependency_dir in local_overrides.values():
+        if dependency_dir.resolve() not in extra_component_dirs:
+            extra_component_dirs.append(dependency_dir.resolve())
+    extra_component_dir_lines = "\n".join(f'    "{path.as_posix()}"' for path in extra_component_dirs)
 
     (project_dir / "CMakeLists.txt").write_text(
         "cmake_minimum_required(VERSION 3.16)\n"
-        f'set(EXTRA_COMPONENT_DIRS "{component_dir.resolve().as_posix()}")\n'
+        "set(EXTRA_COMPONENT_DIRS\n"
+        f"{extra_component_dir_lines}\n"
+        ")\n"
         "include($ENV{IDF_PATH}/tools/cmake/project.cmake)\n"
         "project(component_self_check)\n",
         encoding="utf-8",
@@ -84,6 +135,15 @@ def write_generated_project(component_dir, component_slug):
         "}\n",
         encoding="utf-8",
     )
+    if local_overrides:
+        manifest_lines = ["dependencies:"]
+        for dependency, dependency_dir in sorted(local_overrides.items()):
+            relative_path = os.path.relpath(dependency_dir, project_dir / "main").replace(os.sep, "/")
+            manifest_lines.extend((f"  {dependency}:", f'    path: "{relative_path}"'))
+        (project_dir / "main" / "idf_component.yml").write_text(
+            "\n".join(manifest_lines) + "\n",
+            encoding="utf-8",
+        )
     return project_dir
 
 

--- a/.github/scripts/component_self_check.py
+++ b/.github/scripts/component_self_check.py
@@ -170,6 +170,15 @@ def changed_components(files, component_dirs):
     return sorted(changed)
 
 
+def build_components(changed, component_dirs, upload_dirs):
+    scope = os.environ.get("BUILD_COMPONENT_SCOPE", "changed").strip().lower()
+    if scope in ("all", "full"):
+        return sorted(component_dirs)
+    if scope in ("changed", ""):
+        return list(changed)
+    raise RuntimeError(f"BUILD_COMPONENT_SCOPE must be 'changed' or 'all', got {scope!r}")
+
+
 def manifest_at(ref, component_dir):
     manifest_path = f"{component_dir}/idf_component.yml"
     result = subprocess.run(
@@ -257,20 +266,27 @@ def main():
     base_ref = resolve_base_ref()
     files = changed_files(base_ref)
     components = changed_components(files, component_dirs)
+    output_components = build_components(components, component_dirs, upload_dirs)
 
     unlisted = sorted(set(components) - upload_dirs)
+    output_unlisted = sorted(set(output_components) - upload_dirs)
     errors = []
     if unlisted:
         errors.extend(f"{item}: component is not listed in upload_component.yml" for item in unlisted)
+    if output_unlisted:
+        errors.extend(f"{item}: build component is not listed in upload_component.yml" for item in output_unlisted)
 
     errors.extend(check_version_bumps(base_ref, components))
     errors.extend(check_bsp_codec_dependency())
-    write_outputs(components)
+    write_outputs(output_components)
 
     print(f"Base ref: {base_ref}")
     print(f"Changed files: {len(files)}")
     print(f"Changed components: {len(components)}")
     for component in components:
+        print(f"  - {component}")
+    print(f"Build components: {len(output_components)}")
+    for component in output_components:
         print(f"  - {component}")
 
     if errors:

--- a/.github/workflows/component_self_check.yml
+++ b/.github/workflows/component_self_check.yml
@@ -28,23 +28,28 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
+          BUILD_COMPONENT_SCOPE: all
         run: python .github/scripts/component_self_check.py
 
-  build-changed-components:
+  build-components:
     needs: manifest-check
     if: needs.manifest-check.outputs.count != '0'
     runs-on: ubuntu-latest
-    container: espressif/idf:release-v5.5
+    container:
+      image: espressif/idf:${{ matrix.idf_version }}
     strategy:
       fail-fast: false
       matrix:
         component: ${{ fromJson(needs.manifest-check.outputs.components) }}
+        idf_version:
+          - release-v5.5
+          - release-v6.0
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Build changed component with ESP-IDF v5.5
+      - name: Build component with ESP-IDF ${{ matrix.idf_version }}
         env:
           COMPONENT_DIR: ${{ matrix.component }}
         shell: bash

--- a/bsp/esp32_c6_touch_amoled_1_32/CMakeLists.txt
+++ b/bsp/esp32_c6_touch_amoled_1_32/CMakeLists.txt
@@ -1,7 +1,15 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
 idf_component_register(
     SRCS "esp32_c6_touch_amoled_1_32.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver esp_driver_i2c esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs usb
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )

--- a/bsp/esp32_c6_touch_amoled_1_32/esp32_c6_touch_amoled_1_32.c
+++ b/bsp/esp32_c6_touch_amoled_1_32/esp32_c6_touch_amoled_1_32.c
@@ -517,7 +517,7 @@ lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
     assert(cfg != NULL);
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
 
-    BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
 
     BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
 

--- a/bsp/esp32_c6_touch_amoled_1_32/idf_component.yml
+++ b/bsp/esp32_c6_touch_amoled_1_32/idf_component.yml
@@ -16,4 +16,4 @@ tags:
 targets:
 - esp32c6
 url: https://www.waveshare.com/esp32-c6-touch-amoled-1.32.htm
-version: 1.0.1
+version: 2.0.0

--- a/bsp/esp32_c6_touch_amoled_1_32/include/bsp/display.h
+++ b/bsp/esp32_c6_touch_amoled_1_32/include/bsp/display.h
@@ -14,7 +14,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 /* LCD display definition */
 #define BSP_LCD_H_RES              (466)
 #define BSP_LCD_V_RES              (466)

--- a/bsp/esp32_c6_touch_amoled_2_06/CMakeLists.txt
+++ b/bsp/esp32_c6_touch_amoled_2_06/CMakeLists.txt
@@ -1,7 +1,15 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
 idf_component_register(
     SRCS "esp32_c6_touch_amoled_2_06.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver esp_driver_i2c esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs usb
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )

--- a/bsp/esp32_c6_touch_amoled_2_06/esp32_c6_touch_amoled_2_06.c
+++ b/bsp/esp32_c6_touch_amoled_2_06/esp32_c6_touch_amoled_2_06.c
@@ -544,7 +544,7 @@ lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
     assert(cfg != NULL);
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
 
-    BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
 
     BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
 

--- a/bsp/esp32_c6_touch_amoled_2_06/idf_component.yml
+++ b/bsp/esp32_c6_touch_amoled_2_06/idf_component.yml
@@ -16,4 +16,4 @@ tags:
 targets:
 - esp32c6
 url: https://www.waveshare.com/esp32-c6-touch-amoled-2.06.htm
-version: 1.0.2
+version: 2.0.0

--- a/bsp/esp32_c6_touch_amoled_2_06/include/bsp/display.h
+++ b/bsp/esp32_c6_touch_amoled_2_06/include/bsp/display.h
@@ -14,7 +14,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 /* LCD display definition */
 #define BSP_LCD_H_RES              (410)
 #define BSP_LCD_V_RES              (502)

--- a/bsp/esp32_p4_nano/CMakeLists.txt
+++ b/bsp/esp32_p4_nano/CMakeLists.txt
@@ -1,8 +1,20 @@
 
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2s esp_driver_sdmmc esp_driver_sdspi esp_driver_i2c)
+    set(PRIV_REQ esp_driver_spi esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_p4_nano.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver
-    PRIV_REQUIRES esp_lcd usb spiffs fatfs hal
+    REQUIRES ${REQ} fatfs
+    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram hal
 )

--- a/bsp/esp32_p4_nano/idf_component.yml
+++ b/bsp/esp32_p4_nano/idf_component.yml
@@ -8,12 +8,17 @@ dependencies:
     version: ^2
   idf: '>=5.3'
   lvgl/lvgl: '>=8,<10'
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+      - if: "idf_version >=6.0"
 #  waveshare/esp_lcd_jd9365_10_1: '*'
 #  waveshare/esp_lcd_jd9365_8: '*'
-  waveshare/esp_lcd_jd9365: '*'
-  waveshare/esp_lcd_ili9881c: '*'
-  waveshare/esp_lcd_dsi: '*'
-  waveshare/esp_lcd_hx8394: "^1.0.2"
+  waveshare/esp_lcd_jd9365: "^2.0.0"
+  waveshare/esp_lcd_ili9881c: "^2.0.0"
+  waveshare/esp_lcd_dsi: "^2.0.0"
+  waveshare/esp_lcd_hx8394: "^2.0.0"
 description: a small size and highly integrated development board designed by waveshare
   electronics based on ESP32-P4 chip
 repository: git://github.com/WaveshareCloud/Waveshare-ESP32-components.git
@@ -25,4 +30,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-nano.htm
-version: 1.2.4
+version: 2.0.0

--- a/bsp/esp32_p4_nano/include/bsp/display.h
+++ b/bsp/esp32_p4_nano/include/bsp/display.h
@@ -30,7 +30,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 
 #if CONFIG_BSP_LCD_TYPE_800_1280_10_1_INCH
 #define BSP_LCD_H_RES              (800)

--- a/bsp/esp32_p4_platform/CMakeLists.txt
+++ b/bsp/esp32_p4_platform/CMakeLists.txt
@@ -1,8 +1,20 @@
 
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2s esp_driver_sdmmc esp_driver_sdspi esp_driver_i2c)
+    set(PRIV_REQ esp_driver_spi esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_p4_platform.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver
-    PRIV_REQUIRES esp_lcd usb spiffs fatfs
+    REQUIRES ${REQ} fatfs
+    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram
 )

--- a/bsp/esp32_p4_platform/esp32_p4_platform.c
+++ b/bsp/esp32_p4_platform/esp32_p4_platform.c
@@ -4,6 +4,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "esp_idf_version.h"
 #include "esp_spiffs.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_lcd_mipi_dsi.h"
@@ -668,7 +669,13 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
         }
         i2c_master_bus_rm_device(dev_handle);
     }
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
+    esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG_CF(LCD_COLOR_FMT_RGB888);
+#else
+    esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG_CF(LCD_COLOR_FMT_RGB565);
+#endif
+#elif CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
     esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG(LCD_COLOR_PIXEL_FORMAT_RGB888);
 #else
     esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG(LCD_COLOR_PIXEL_FORMAT_RGB565);
@@ -746,7 +753,13 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,  
         .dpi_clock_freq_mhz = 30,                     
         .virtual_channel = 0,               
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
+        .in_color_format = LCD_COLOR_FMT_RGB888,
+#else
+        .in_color_format = LCD_COLOR_FMT_RGB565,
+#endif
+#elif CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
         .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB888,                    
 #else
         .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB565,                    
@@ -762,7 +775,9 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
             .vsync_pulse_width = 8,                   
             .vsync_front_porch = 60,                  
         },                                            
-        .flags.use_dma2d = true,                      
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+        .flags.use_dma2d = true,
+#endif
     };
     dpi_config.num_fbs = CONFIG_BSP_LCD_DPI_BUFFER_NUMS;
 

--- a/bsp/esp32_p4_platform/idf_component.yml
+++ b/bsp/esp32_p4_platform/idf_component.yml
@@ -5,16 +5,21 @@ dependencies:
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
     public: true
-    version: "0.1.*"
+    version: "^0.5.1"
   idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
-  waveshare/esp_lcd_jd9365: '*'
-  waveshare/esp_lcd_ili9881c: '*'
-  waveshare/esp_lcd_dsi: '*'
-  waveshare/esp_lcd_hx8394: "^1.0.2"
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+      - if: "idf_version >=6.0"
+  waveshare/esp_lcd_jd9365: "^2.0.0"
+  waveshare/esp_lcd_ili9881c: "^2.0.0"
+  waveshare/esp_lcd_dsi: "^2.0.0"
+  waveshare/esp_lcd_hx8394: "^2.0.0"
   espressif/esp_lcd_st7701: '*'
-  waveshare/esp_lcd_ota7290b: '*'
-  esp_lcd_ek79007: 1.*
+  waveshare/esp_lcd_ota7290b: "^2.0.0"
+  esp_lcd_ek79007: "^2.0.2~1"
 description: a small size and highly integrated development board designed by waveshare
   electronics based on ESP32-P4 chip
 repository: git://github.com/WaveshareCloud/Waveshare-ESP32-components.git
@@ -23,4 +28,4 @@ tags:
 targets:
 - esp32p4
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.0.7
+version: 2.0.0

--- a/bsp/esp32_p4_platform/include/bsp/display.h
+++ b/bsp/esp32_p4_platform/include/bsp/display.h
@@ -18,7 +18,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 
 #if CONFIG_BSP_LCD_TYPE_800_1280_10_1_INCH_A
 #define BSP_LCD_H_RES              (800)

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/CMakeLists.txt
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/CMakeLists.txt
@@ -1,8 +1,20 @@
 
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2s esp_driver_sdmmc esp_driver_sdspi esp_driver_i2c)
+    set(PRIV_REQ esp_driver_spi esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_p4_wifi6_touch_lcd_4b.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver
-    PRIV_REQUIRES esp_lcd usb spiffs fatfs
+    REQUIRES ${REQ} fatfs
+    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram
 )

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/idf_component.yml
@@ -8,7 +8,12 @@ dependencies:
     version: ^2
   idf: '>=5.4'
   lvgl/lvgl: '>=8,<10'
-  waveshare/esp_lcd_st7703: '*'
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+      - if: "idf_version >=6.0"
+  waveshare/esp_lcd_st7703: "^2.0.0"
 description: Based on ESP32-P4 chip, waveshare electronics designed a 3.4-inch, 4-inch circular screen, highly integrated development board
 repository: git://github.com/WaveshareCloud/Waveshare-ESP32-components.git
 tags:
@@ -16,4 +21,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-3.4c.htm
-version: 1.0.4
+version: 2.0.0

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/display.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/display.h
@@ -18,7 +18,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 
 #define BSP_LCD_H_RES              (720)
 #define BSP_LCD_V_RES              (720)

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/CMakeLists.txt
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/CMakeLists.txt
@@ -1,8 +1,20 @@
 
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2s esp_driver_sdmmc esp_driver_sdspi esp_driver_i2c)
+    set(PRIV_REQ esp_driver_spi esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_p4_wifi6_touch_lcd_7b.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver
-    PRIV_REQUIRES esp_lcd usb spiffs fatfs
+    REQUIRES ${REQ} fatfs
+    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram
 )

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
@@ -10,6 +10,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "esp_idf_version.h"
 #include "esp_spiffs.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_lcd_mipi_dsi.h"
@@ -440,7 +441,13 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
     // create EK79007 control panel
     ESP_LOGI(TAG, "Install EK79007 LCD control panel");
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
+    esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG_CF(LCD_COLOR_FMT_RGB888);
+#else
+    esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG_CF(LCD_COLOR_FMT_RGB565);
+#endif
+#elif CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
     esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG(LCD_COLOR_PIXEL_FORMAT_RGB888);
 #else
     esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG(LCD_COLOR_PIXEL_FORMAT_RGB565);
@@ -454,7 +461,11 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
         },
     };
     esp_lcd_panel_dev_config_t lcd_dev_config = {
+#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
+        .bits_per_pixel = 24,
+#else
         .bits_per_pixel = 16,
+#endif
         .rgb_ele_order = BSP_LCD_COLOR_SPACE,
         .reset_gpio_num = BSP_LCD_RST,
         .vendor_config = &vendor_config,

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/idf_component.yml
@@ -2,13 +2,18 @@ dependencies:
   esp_codec_dev:
     public: true
     version: "~1.5"
-  esp_lcd_ek79007: 1.*
+  esp_lcd_ek79007: "^2.0.2~1"
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_port:
     public: true
     version: ^2
   idf: '>=5.3'
   lvgl/lvgl: '>=8,<10'
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+      - if: "idf_version >=6.0"
 description: Based on ESP32-P4 chip, waveshare electronics designed a 7-inch screen, highly integrated development board
 repository: git://github.com/WaveshareCloud/Waveshare-ESP32-components.git
 tags:
@@ -16,4 +21,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-7b.htm
-version: 1.0.4
+version: 2.0.0

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/display.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/display.h
@@ -34,7 +34,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 
 /* LCD display definition 1024x600 */
 #define BSP_LCD_H_RES              (1024)

--- a/bsp/esp32_p4_wifi6_touch_lcd_x/CMakeLists.txt
+++ b/bsp/esp32_p4_wifi6_touch_lcd_x/CMakeLists.txt
@@ -1,8 +1,20 @@
 
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2s esp_driver_sdmmc esp_driver_sdspi esp_driver_i2c)
+    set(PRIV_REQ esp_driver_spi esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_p4_wifi6_touch_lcd_x.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver
-    PRIV_REQUIRES esp_lcd usb spiffs fatfs
+    REQUIRES ${REQ} fatfs
+    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram
 )

--- a/bsp/esp32_p4_wifi6_touch_lcd_x/esp32_p4_wifi6_touch_lcd_x.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_x/esp32_p4_wifi6_touch_lcd_x.c
@@ -4,6 +4,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "esp_idf_version.h"
 #include "esp_spiffs.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_lcd_mipi_dsi.h"
@@ -1129,10 +1130,16 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,       
         .dpi_clock_freq_mhz = 80,                          
         .virtual_channel = 0,                  
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
-        .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB888,                   
+        .in_color_format = LCD_COLOR_FMT_RGB888,
 #else
-        .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB565,                   
+        .in_color_format = LCD_COLOR_FMT_RGB565,
+#endif
+#elif CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
+        .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB888,
+#else
+        .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB565,
 #endif
         .num_fbs = CONFIG_BSP_LCD_DPI_BUFFER_NUMS,                                      
         .video_timing = {                                  

--- a/bsp/esp32_p4_wifi6_touch_lcd_x/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_x/idf_component.yml
@@ -5,11 +5,16 @@ dependencies:
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
     public: true
-    version: "0.1.*"
+    version: "^0.5.1"
   idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
-  esp_lcd_jd9365: '*'
-  esp_lcd_ili9881c: '*'
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+      - if: "idf_version >=6.0"
+  esp_lcd_jd9365: "^2.0.0"
+  esp_lcd_ili9881c: "^2.0.0"
 description: ESP32-P4 HMI Touch All-in-One Machine
 repository: git://github.com/WaveshareCloud/Waveshare-ESP32-components.git
 tags:
@@ -17,4 +22,4 @@ tags:
 targets:
 - esp32p4
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.0.2
+version: 2.0.0

--- a/bsp/esp32_p4_wifi6_touch_lcd_x/include/bsp/display.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_x/include/bsp/display.h
@@ -18,7 +18,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 
 #if CONFIG_BSP_LCD_TYPE_800_1280_10_1_INCH
 #define BSP_LCD_H_RES              (800)

--- a/bsp/esp32_p4_wifi6_touch_lcd_xc/CMakeLists.txt
+++ b/bsp/esp32_p4_wifi6_touch_lcd_xc/CMakeLists.txt
@@ -1,8 +1,20 @@
 
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2s esp_driver_sdmmc esp_driver_sdspi esp_driver_i2c)
+    set(PRIV_REQ esp_driver_spi esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_p4_wifi6_touch_lcd_xc.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver
-    PRIV_REQUIRES esp_lcd usb spiffs fatfs
+    REQUIRES ${REQ} fatfs
+    PRIV_REQUIRES ${PRIV_REQ} esp_lcd spiffs esp_psram
 )

--- a/bsp/esp32_p4_wifi6_touch_lcd_xc/esp32_p4_wifi6_touch_lcd_xc.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_xc/esp32_p4_wifi6_touch_lcd_xc.c
@@ -4,6 +4,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "esp_idf_version.h"
 #include "esp_spiffs.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_lcd_mipi_dsi.h"
@@ -871,7 +872,13 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,
         .dpi_clock_freq_mhz = 80,
         .virtual_channel = 0,
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
+        .in_color_format = LCD_COLOR_FMT_RGB888,
+#else
+        .in_color_format = LCD_COLOR_FMT_RGB565,
+#endif
+#elif CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
         .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB888,
 #else
         .pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB565,
@@ -887,7 +894,9 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
             .vsync_pulse_width = 4,
             .vsync_front_porch = 24,
         },
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
         .flags.use_dma2d = true,
+#endif
     };
     dpi_config.num_fbs = CONFIG_BSP_LCD_DPI_BUFFER_NUMS;
 

--- a/bsp/esp32_p4_wifi6_touch_lcd_xc/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_xc/idf_component.yml
@@ -2,13 +2,18 @@ dependencies:
   esp_codec_dev:
     version: "~1.5"
     public: true
-  esp_lcd_jd9365: '*'
+  esp_lcd_jd9365: "^2.0.0"
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
     public: true
-    version: "0.1.*"
+    version: "^0.5.1"
   idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+      - if: "idf_version >=6.0"
 description: Based on ESP32-P4 chip, waveshare electronics designed a 3.4-inch, 4-inch
   circular screen, highly integrated development board
 repository: git://github.com/waveshareteam/Waveshare-ESP32-components.git
@@ -17,4 +22,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-3.4c.htm
-version: 2.0.1
+version: 3.0.0

--- a/bsp/esp32_p4_wifi6_touch_lcd_xc/include/bsp/display.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_xc/include/bsp/display.h
@@ -18,7 +18,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 
 #if CONFIG_BSP_LCD_TYPE_800_800_3_4_INCH
 #define BSP_LCD_H_RES              (800)

--- a/bsp/esp32_s3_cam_ovxxxx/CMakeLists.txt
+++ b/bsp/esp32_s3_cam_ovxxxx/CMakeLists.txt
@@ -1,7 +1,19 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc esp_driver_sdspi)
+    set(PRIV_REQ esp_driver_spi)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_cam_ovxxxx.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES fatfs esp_driver_i2c esp_driver_gpio esp_lcd esp32-camera custom_io_expander_ch32v003
-    PRIV_REQUIRES esp_timer spiffs esp_psram usb
+    REQUIRES ${REQ} fatfs esp_lcd esp32-camera custom_io_expander_ch32v003
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram
 )

--- a/bsp/esp32_s3_cam_ovxxxx/idf_component.yml
+++ b/bsp/esp32_s3_cam_ovxxxx/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.0.0
+version: 2.0.0
 description: Board Support Package (BSP) for Waveshare ESP32-S3-CAM-OVxxxx
 url: https://www.waveshare.com/esp32-s3-cam-ovxxxx.htm
 
@@ -9,6 +9,11 @@ tags:
 - bsp
 
 dependencies:
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
   idf: ">=5.3"
   lvgl/lvgl: ">=8,<10"
   espressif/esp_lvgl_adapter:

--- a/bsp/esp32_s3_cam_ovxxxx/include/bsp/esp32_s3_cam_ovxxxx.h
+++ b/bsp/esp32_s3_cam_ovxxxx/include/bsp/esp32_s3_cam_ovxxxx.h
@@ -39,7 +39,7 @@
  *  @brief BSP Board Name
  *  @{
  */
-#define ESP32-S3-CAM-XXXX
+#define ESP32_S3_CAM_OVXXXX
 /** @} */ // end of boardname
 
 /**************************************************************************************************

--- a/bsp/esp32_s3_lr1121_oled_1_54/CMakeLists.txt
+++ b/bsp/esp32_s3_lr1121_oled_1_54/CMakeLists.txt
@@ -1,8 +1,14 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc esp_driver_spi esp_driver_tsens)
+else()
+    set(REQ driver)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_lr1121_oled_1_54.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES esp_driver_i2c  esp_driver_gpio lvgl__lvgl espressif__esp_lvgl_adapter
+    REQUIRES ${REQ} lvgl__lvgl espressif__esp_lvgl_adapter
     PRIV_REQUIRES esp_timer spiffs esp_psram fatfs
 )
 

--- a/bsp/esp32_s3_lr1121_oled_1_54/esp32_s3_lr1121_oled_1_54.c
+++ b/bsp/esp32_s3_lr1121_oled_1_54/esp32_s3_lr1121_oled_1_54.c
@@ -692,7 +692,7 @@ esp_err_t bsp_enable_rtc_alarm()
 
 esp_err_t bsp_datetime_to_str(char *datetime_str, pcf85063a_datetime_t time)
 {
-    pcf85063a_datetime_to_str(datetime_str, time);
+    pcf85063a_datetime_to_str(datetime_str, 32, time);
     return ESP_OK;
 }
 

--- a/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
+++ b/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
@@ -29,4 +29,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.1.0
+version: 2.0.0

--- a/bsp/esp32_s3_touch_amoled_1_32/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_amoled_1_32/CMakeLists.txt
@@ -1,7 +1,19 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_amoled_1_32.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver esp_driver_i2c esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs usb
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )

--- a/bsp/esp32_s3_touch_amoled_1_32/esp32_s3_touch_amoled_1_32.c
+++ b/bsp/esp32_s3_touch_amoled_1_32/esp32_s3_touch_amoled_1_32.c
@@ -517,7 +517,7 @@ lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
     assert(cfg != NULL);
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
 
-    BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
 
     BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
 

--- a/bsp/esp32_s3_touch_amoled_1_32/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_1_32/idf_component.yml
@@ -1,4 +1,9 @@
 dependencies:
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
   esp_codec_dev:
     version: "~1.5"
     public: true
@@ -16,4 +21,4 @@ tags:
 targets:
 - esp32s3
 url: https://www.waveshare.com/esp32-s3-touch-amoled-1.32.htm
-version: 1.0.1
+version: 2.0.0

--- a/bsp/esp32_s3_touch_amoled_1_32/include/bsp/display.h
+++ b/bsp/esp32_s3_touch_amoled_1_32/include/bsp/display.h
@@ -14,7 +14,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 /* LCD display definition */
 #define BSP_LCD_H_RES              (466)
 #define BSP_LCD_V_RES              (466)

--- a/bsp/esp32_s3_touch_amoled_1_75/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_amoled_1_75/CMakeLists.txt
@@ -1,7 +1,19 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_amoled_1_75.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver esp_driver_i2c esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs usb
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )

--- a/bsp/esp32_s3_touch_amoled_1_75/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_1_75/idf_component.yml
@@ -1,4 +1,4 @@
-version: 2.0.6
+version: 3.0.0
 description: Board Support Package (BSP) for Waveshare ESP32-S3-Touch-AMOLED-1.75
 url: https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm
 
@@ -9,6 +9,11 @@ tags:
 - bsp
 
 dependencies:
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
   idf: ">=5.5"
   lvgl/lvgl: ">=8,<10"
   esp_lcd_co5300: "*"

--- a/bsp/esp32_s3_touch_amoled_1_75/include/bsp/display.h
+++ b/bsp/esp32_s3_touch_amoled_1_75/include/bsp/display.h
@@ -15,7 +15,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 /* LCD display definition */
 #define BSP_LCD_H_RES              (466)
 #define BSP_LCD_V_RES              (466)

--- a/bsp/esp32_s3_touch_amoled_1_8/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_amoled_1_8/CMakeLists.txt
@@ -1,7 +1,19 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_amoled_1_8.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver esp_driver_i2c esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs usb
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )

--- a/bsp/esp32_s3_touch_amoled_1_8/esp32_s3_touch_amoled_1_8.c
+++ b/bsp/esp32_s3_touch_amoled_1_8/esp32_s3_touch_amoled_1_8.c
@@ -567,7 +567,7 @@ lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
     assert(cfg != NULL);
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
 
-    BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
 
     BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
 

--- a/bsp/esp32_s3_touch_amoled_1_8/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_1_8/idf_component.yml
@@ -1,4 +1,9 @@
 dependencies:
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
   esp_codec_dev:
     version: "~1.5"
     public: true
@@ -20,4 +25,4 @@ tags:
 targets:
 - esp32s3
 url: https://www.waveshare.com/esp32-s3-touch-amoled-1.8.htm
-version: 1.1.4
+version: 2.0.0

--- a/bsp/esp32_s3_touch_amoled_1_8/include/bsp/display.h
+++ b/bsp/esp32_s3_touch_amoled_1_8/include/bsp/display.h
@@ -14,7 +14,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 /* LCD display definition */
 #define BSP_LCD_H_RES              (368)
 #define BSP_LCD_V_RES              (448)

--- a/bsp/esp32_s3_touch_amoled_2_06/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_amoled_2_06/CMakeLists.txt
@@ -1,7 +1,19 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_amoled_2_06.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver esp_driver_i2c esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs usb
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )

--- a/bsp/esp32_s3_touch_amoled_2_06/esp32_s3_touch_amoled_2_06.c
+++ b/bsp/esp32_s3_touch_amoled_2_06/esp32_s3_touch_amoled_2_06.c
@@ -617,7 +617,7 @@ lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
     assert(cfg != NULL);
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
 
-    BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
 
     BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
 

--- a/bsp/esp32_s3_touch_amoled_2_06/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_2_06/idf_component.yml
@@ -1,4 +1,9 @@
 dependencies:
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
   esp_codec_dev:
     version: "~1.5"
     public: true
@@ -16,4 +21,4 @@ tags:
 targets:
 - esp32s3
 url: https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm
-version: 1.0.7
+version: 2.0.0

--- a/bsp/esp32_s3_touch_amoled_2_06/include/bsp/display.h
+++ b/bsp/esp32_s3_touch_amoled_2_06/include/bsp/display.h
@@ -14,7 +14,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 /* LCD display definition */
 #define BSP_LCD_H_RES              (410)
 #define BSP_LCD_V_RES              (502)

--- a/bsp/esp32_s3_touch_amoled_2_16/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_amoled_2_16/CMakeLists.txt
@@ -1,7 +1,19 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_amoled_2_16.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver esp_driver_i2c esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs usb
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )

--- a/bsp/esp32_s3_touch_amoled_2_16/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_2_16/idf_component.yml
@@ -1,4 +1,9 @@
 dependencies:
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
   esp_codec_dev:
     version: "~1.5"
     public: true
@@ -16,4 +21,4 @@ tags:
 targets:
 - esp32s3
 url: https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm
-version: 1.0.0
+version: 2.0.0

--- a/bsp/esp32_s3_touch_amoled_2_16/include/bsp/display.h
+++ b/bsp/esp32_s3_touch_amoled_2_16/include/bsp/display.h
@@ -14,7 +14,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 /* LCD display definition */
 #define BSP_LCD_H_RES              (480)
 #define BSP_LCD_V_RES              (480)

--- a/bsp/esp32_s3_touch_lcd_1_69/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_lcd_1_69/CMakeLists.txt
@@ -1,7 +1,19 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_lcd_1_69.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver esp_driver_i2c esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs usb
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )

--- a/bsp/esp32_s3_touch_lcd_1_69/esp32_s3_touch_lcd_1_69.c
+++ b/bsp/esp32_s3_touch_lcd_1_69/esp32_s3_touch_lcd_1_69.c
@@ -341,7 +341,7 @@ lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
     assert(cfg != NULL);
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
 
-    BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
 
     BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
 

--- a/bsp/esp32_s3_touch_lcd_1_69/idf_component.yml
+++ b/bsp/esp32_s3_touch_lcd_1_69/idf_component.yml
@@ -1,4 +1,9 @@
 dependencies:
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
   esp_lcd_touch_cst816s: "*"
   espressif/esp_lvgl_port:
     public: true
@@ -12,4 +17,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.0.4
+version: 2.0.0

--- a/bsp/esp32_s3_touch_lcd_1_69/include/bsp/display.h
+++ b/bsp/esp32_s3_touch_lcd_1_69/include/bsp/display.h
@@ -14,7 +14,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 /* LCD display definition */
 #define BSP_LCD_H_RES              (240)
 #define BSP_LCD_V_RES              (280)

--- a/bsp/esp32_s3_touch_lcd_1_83/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_lcd_1_83/CMakeLists.txt
@@ -1,7 +1,19 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
+if(${IDF_VERSION_MAJOR} LESS 6)
+    list(APPEND PRIV_REQ usb)
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_lcd_1_83.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES driver esp_driver_i2c esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs usb
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )

--- a/bsp/esp32_s3_touch_lcd_1_83/esp32_s3_touch_lcd_1_83.c
+++ b/bsp/esp32_s3_touch_lcd_1_83/esp32_s3_touch_lcd_1_83.c
@@ -547,7 +547,7 @@ lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
     assert(cfg != NULL);
     BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
 
-    BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(), NULL);
 
     BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
 

--- a/bsp/esp32_s3_touch_lcd_1_83/idf_component.yml
+++ b/bsp/esp32_s3_touch_lcd_1_83/idf_component.yml
@@ -1,4 +1,9 @@
 dependencies:
+  usb:
+    version: "^1.0.0"
+    public: true
+    rules:
+     - if: "idf_version >=6.0"
   esp_codec_dev:
     version: "~1.5"
     public: true
@@ -15,4 +20,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.0.5
+version: 2.0.0

--- a/bsp/esp32_s3_touch_lcd_1_83/include/bsp/display.h
+++ b/bsp/esp32_s3_touch_lcd_1_83/include/bsp/display.h
@@ -14,7 +14,7 @@
 /* LCD display color bits */
 #define BSP_LCD_BITS_PER_PIXEL      (16)
 /* LCD display color space */
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 /* LCD display definition */
 #define BSP_LCD_H_RES              (240)
 #define BSP_LCD_V_RES              (284)

--- a/bsp/esp32_s3_touch_lcd_2_8d/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_lcd_2_8d/CMakeLists.txt
@@ -1,8 +1,16 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_lcd_2_8d.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES esp_driver_i2c  esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )
 

--- a/bsp/esp32_s3_touch_lcd_2_8d/esp32_s3_touch_lcd_2_8d.c
+++ b/bsp/esp32_s3_touch_lcd_2_8d/esp32_s3_touch_lcd_2_8d.c
@@ -5,6 +5,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "esp_idf_version.h"
 #include "esp_vfs_fat.h"
 #include "esp_spiffs.h"
 #include "driver/gpio.h"
@@ -487,9 +488,17 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
 
     esp_lcd_rgb_panel_config_t rgb_config = {
            .clk_src = LCD_CLK_SRC_DEFAULT,
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+           .in_color_format = LCD_COLOR_FMT_RGB565,
+           .out_color_format = LCD_COLOR_FMT_RGB565,
+           .dma_burst_size = 64,
+#else
            .psram_trans_align = 64,
+#endif
            .data_width = BSP_RGB_DATA_WIDTH,
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
            .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
+#endif
            .de_gpio_num = BSP_LCD_DE,
            .pclk_gpio_num = BSP_LCD_PCLK,
            .vsync_gpio_num = BSP_LCD_VSYNC,
@@ -780,7 +789,7 @@ esp_err_t bsp_enable_rtc_alarm()
 
 esp_err_t bsp_datetime_to_str(char *datetime_str, pcf85063a_datetime_t time)
 {
-    pcf85063a_datetime_to_str(datetime_str, time);
+    pcf85063a_datetime_to_str(datetime_str, 32, time);
     return ESP_OK;
 }
 

--- a/bsp/esp32_s3_touch_lcd_2_8d/idf_component.yml
+++ b/bsp/esp32_s3_touch_lcd_2_8d/idf_component.yml
@@ -29,4 +29,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.0.2
+version: 2.0.0

--- a/bsp/esp32_s3_touch_lcd_4/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_lcd_4/CMakeLists.txt
@@ -1,8 +1,16 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_sdmmc)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_lcd_4.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES esp_driver_i2c  esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )
 

--- a/bsp/esp32_s3_touch_lcd_4/esp32_s3_touch_lcd_4.c
+++ b/bsp/esp32_s3_touch_lcd_4/esp32_s3_touch_lcd_4.c
@@ -5,6 +5,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "esp_idf_version.h"
 #include "esp_vfs_fat.h"
 #include "esp_spiffs.h"
 #include "driver/gpio.h"
@@ -282,9 +283,17 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
 
     esp_lcd_rgb_panel_config_t rgb_config = {
         .clk_src = LCD_CLK_SRC_DEFAULT,
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+        .in_color_format = LCD_COLOR_FMT_RGB565,
+        .out_color_format = LCD_COLOR_FMT_RGB565,
+        .dma_burst_size = 64,
+#else
         .psram_trans_align = 64,
+#endif
         .data_width = BSP_RGB_DATA_WIDTH,
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
         .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
+#endif
         .de_gpio_num = BSP_LCD_DE,
         .pclk_gpio_num = BSP_LCD_PCLK,
         .vsync_gpio_num = BSP_LCD_VSYNC,

--- a/bsp/esp32_s3_touch_lcd_4/idf_component.yml
+++ b/bsp/esp32_s3_touch_lcd_4/idf_component.yml
@@ -17,4 +17,4 @@ tags:
 targets:
 - esp32s3
 url: https://www.waveshare.com/esp32-s3-touch-lcd-4.htm
-version: 2.0.0
+version: 3.0.0

--- a/bsp/esp32_s3_touch_lcd_4_3c/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_lcd_4_3c/CMakeLists.txt
@@ -1,8 +1,16 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s esp_driver_sdmmc esp_driver_usb_serial_jtag esp_driver_tsens)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_lcd_4_3c.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES esp_driver_i2c  esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )
 

--- a/bsp/esp32_s3_touch_lcd_4_3c/esp32_s3_touch_lcd_4_3c.c
+++ b/bsp/esp32_s3_touch_lcd_4_3c/esp32_s3_touch_lcd_4_3c.c
@@ -5,6 +5,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "esp_idf_version.h"
 #include "esp_vfs_fat.h"
 #include "esp_spiffs.h"
 #include "driver/gpio.h"
@@ -466,9 +467,17 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
 
     esp_lcd_rgb_panel_config_t rgb_config = {
         .clk_src = LCD_CLK_SRC_PLL160M,
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+        .in_color_format = LCD_COLOR_FMT_RGB565,
+        .out_color_format = LCD_COLOR_FMT_RGB565,
+        .dma_burst_size = 64,
+#else
         .psram_trans_align = 64,
+#endif
         .data_width = BSP_RGB_DATA_WIDTH,
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
         .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
+#endif
         .de_gpio_num = BSP_LCD_DE,
         .pclk_gpio_num = BSP_LCD_PCLK,
         .vsync_gpio_num = BSP_LCD_VSYNC,
@@ -773,6 +782,6 @@ esp_err_t bsp_enable_rtc_alarm()
 
 esp_err_t bsp_datetime_to_str(char *datetime_str, pcf85063a_datetime_t time)
 {
-    pcf85063a_datetime_to_str(datetime_str, time);
+    pcf85063a_datetime_to_str(datetime_str, 32, time);
     return ESP_OK;
 }

--- a/bsp/esp32_s3_touch_lcd_4_3c/idf_component.yml
+++ b/bsp/esp32_s3_touch_lcd_4_3c/idf_component.yml
@@ -24,4 +24,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 2.0.1
+version: 3.0.0

--- a/bsp/esp32_s3_touch_lcd_4b/CMakeLists.txt
+++ b/bsp/esp32_s3_touch_lcd_4b/CMakeLists.txt
@@ -1,8 +1,16 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_gpio esp_driver_i2c esp_driver_i2s)
+    set(PRIV_REQ esp_driver_ledc)
+else()
+    set(REQ driver)
+    set(PRIV_REQ "")
+endif()
+
 idf_component_register(
     SRCS "esp32_s3_touch_lcd_4b.c" ${SRC_VER}
     INCLUDE_DIRS "include" "include/bsp"
     PRIV_INCLUDE_DIRS "priv_include"
-    REQUIRES esp_driver_i2c  esp_driver_gpio esp_lcd
-    PRIV_REQUIRES esp_timer spiffs esp_psram fatfs
+    REQUIRES ${REQ} esp_lcd
+    PRIV_REQUIRES ${PRIV_REQ} esp_timer spiffs esp_psram fatfs
 )
 

--- a/bsp/esp32_s3_touch_lcd_4b/esp32_s3_touch_lcd_4b.c
+++ b/bsp/esp32_s3_touch_lcd_4b/esp32_s3_touch_lcd_4b.c
@@ -5,6 +5,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "esp_idf_version.h"
 #include "esp_vfs_fat.h"
 #include "esp_spiffs.h"
 #include "driver/gpio.h"
@@ -419,9 +420,17 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
 
     esp_lcd_rgb_panel_config_t rgb_config = {
            .clk_src = LCD_CLK_SRC_DEFAULT,
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+           .in_color_format = LCD_COLOR_FMT_RGB565,
+           .out_color_format = LCD_COLOR_FMT_RGB565,
+           .dma_burst_size = 64,
+#else
            .psram_trans_align = 64,
+#endif
            .data_width = BSP_RGB_DATA_WIDTH,
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
            .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
+#endif
            .de_gpio_num = BSP_LCD_DE,
            .pclk_gpio_num = BSP_LCD_PCLK,
            .vsync_gpio_num = BSP_LCD_VSYNC,

--- a/bsp/esp32_s3_touch_lcd_4b/idf_component.yml
+++ b/bsp/esp32_s3_touch_lcd_4b/idf_component.yml
@@ -20,4 +20,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.1.2
+version: 2.0.0

--- a/display/lcd/esp_lcd_axs15260d/CMakeLists.txt
+++ b/display/lcd/esp_lcd_axs15260d/CMakeLists.txt
@@ -1,5 +1,12 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS "esp_lcd_axs15260d.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES "esp_lcd")
+                       REQUIRES "esp_lcd"
+                       PRIV_REQUIRES ${PRIV_REQ})
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_axs15260d/idf_component.yml
+++ b/display/lcd/esp_lcd_axs15260d/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.0.2"
+version: 2.0.0
 license: "MIT"
 targets:
   - esp32p4

--- a/display/lcd/esp_lcd_axs15260d/include/esp_lcd_axs15260d.h
+++ b/display/lcd/esp_lcd_axs15260d/include/esp_lcd_axs15260d.h
@@ -148,6 +148,19 @@ esp_err_t esp_lcd_new_panel_axs15260d(const esp_lcd_panel_io_handle_t io, const 
         },                                                       \
     }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define AXS15260D_452_1280_PANEL_60HZ_DPI_CONFIG(color_format) AXS15260D_452_1280_PANEL_60HZ_DPI_CONFIG_CF(color_format)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/display/lcd/esp_lcd_axs15260d/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_axs15260d/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_axs15260d.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_axs15260d.c"
+                       REQUIRES esp_lcd_axs15260d esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/lcd/esp_lcd_axs15260d/test_apps/main/test_esp_lcd_axs15260d.c
+++ b/display/lcd/esp_lcd_axs15260d/test_apps/main/test_esp_lcd_axs15260d.c
@@ -5,7 +5,6 @@
  */
 
 #include "esp_err.h"
-#include "freertos/projdefs.h"
 #include "soc/soc_caps.h"
 #include <stdint.h>
 

--- a/display/lcd/esp_lcd_dsi/CMakeLists.txt
+++ b/display/lcd/esp_lcd_dsi/CMakeLists.txt
@@ -1,6 +1,13 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS "esp_lcd_dsi.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES "esp_lcd")
+                       REQUIRES "esp_lcd"
+                       PRIV_REQUIRES ${PRIV_REQ})
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_dsi/esp_lcd_dsi.c
+++ b/display/lcd/esp_lcd_dsi/esp_lcd_dsi.c
@@ -12,6 +12,7 @@
 #include "freertos/task.h"
 #include "driver/gpio.h"
 #include "esp_lcd_dsi.h"
+#include "esp_idf_version.h"
 
 #include "i2c_bus.h"
 
@@ -67,7 +68,7 @@ esp_err_t esp_lcd_new_panel_dsi(const esp_lcd_panel_io_handle_t io, const esp_lc
         ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
     }
 
-    switch (panel_dev_config->color_space)
+    switch (panel_dev_config->rgb_ele_order)
     {
     case LCD_RGB_ELEMENT_ORDER_RGB:
         dsi->madctl_val = 0;
@@ -120,6 +121,9 @@ esp_err_t esp_lcd_new_panel_dsi(const esp_lcd_panel_io_handle_t io, const esp_lc
     esp_lcd_panel_handle_t panel_handle = NULL;
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_dpi(vendor_config->mipi_config.dsi_bus, vendor_config->mipi_config.dpi_config, &panel_handle), err, TAG,
                       "create MIPI DPI panel failed");
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ESP_GOTO_ON_ERROR(esp_lcd_dpi_panel_enable_dma2d(panel_handle), err, TAG, "enable MIPI DPI DMA2D failed");
+#endif
     ESP_LOGD(TAG, "new MIPI DPI panel @%p", panel_handle);
 
     // Save the original functions of MIPI DPI panel

--- a/display/lcd/esp_lcd_dsi/idf_component.yml
+++ b/display/lcd/esp_lcd_dsi/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.8"
+version: "2.0.0"
 targets:
   - esp32p4
 description: "Waveshare DSI display driver, compatible with a variety of DSI displays"

--- a/display/lcd/esp_lcd_dsi/include/esp_lcd_dsi.h
+++ b/display/lcd/esp_lcd_dsi/include/esp_lcd_dsi.h
@@ -6,6 +6,26 @@
 #if SOC_MIPI_DSI_SUPPORTED
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_mipi_dsi.h"
+#include "esp_idf_version.h"
+
+#ifndef WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .in_color_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D
+#else
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .pixel_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D .flags.use_dma2d = true,
+#endif
+#endif
 
 #ifdef __cplusplus
 extern "C"
@@ -100,7 +120,7 @@ extern "C"
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 480,                               \
@@ -112,14 +132,14 @@ extern "C"
             .vsync_pulse_width = 150,                    \
             .vsync_front_porch = 150,                    \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_3_4_INCH_C_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 800,                               \
@@ -131,14 +151,14 @@ extern "C"
             .vsync_pulse_width = 4,                      \
             .vsync_front_porch = 16,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_4_INCH_C_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 720,                               \
@@ -150,14 +170,14 @@ extern "C"
             .vsync_pulse_width = 16,                     \
             .vsync_front_porch = 8,                      \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_4_INCH_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48.6,                      \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 480,                               \
@@ -169,14 +189,14 @@ extern "C"
             .vsync_pulse_width = 100,                    \
             .vsync_front_porch = 20,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_5_INCH_D_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 720,                               \
@@ -188,14 +208,14 @@ extern "C"
             .vsync_pulse_width = 20,                     \
             .vsync_front_porch = 20,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_6_25_INCH_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 720,                               \
@@ -207,14 +227,14 @@ extern "C"
             .vsync_pulse_width = 20,                     \
             .vsync_front_porch = 20,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_5_INCH_C_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 1024,                              \
@@ -226,14 +246,14 @@ extern "C"
             .vsync_pulse_width = 10,                     \
             .vsync_front_porch = 10,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_7_INCH_C_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 1024,                              \
@@ -245,14 +265,14 @@ extern "C"
             .vsync_pulse_width = 10,                     \
             .vsync_front_porch = 10,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_7_9_INCH_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 400,                               \
@@ -264,14 +284,14 @@ extern "C"
             .vsync_pulse_width = 10,                     \
             .vsync_front_porch = 20,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_7_INCH_E_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 1280,                              \
@@ -283,14 +303,14 @@ extern "C"
             .vsync_pulse_width = 40,                     \
             .vsync_front_porch = 40,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_7_INCH_H_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 1280,                              \
@@ -302,14 +322,14 @@ extern "C"
             .vsync_pulse_width = 64,                     \
             .vsync_front_porch = 64,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_8_INCH_C_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 1280,                              \
@@ -321,14 +341,14 @@ extern "C"
             .vsync_pulse_width = 40,                     \
             .vsync_front_porch = 40,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_10_1_INCH_C_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 1280,                              \
@@ -340,14 +360,14 @@ extern "C"
             .vsync_pulse_width = 40,                     \
             .vsync_front_porch = 40,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_8_8_INCH_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 480,                               \
@@ -359,14 +379,14 @@ extern "C"
             .vsync_pulse_width = 20,                     \
             .vsync_front_porch = 20,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #define DSI_PANEL_DPI_11_9_INCH_CONFIG(px_format) \
     {                                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 48,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 320,                               \
@@ -378,7 +398,7 @@ extern "C"
             .vsync_pulse_width = 60,                     \
             .vsync_front_porch = 60,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #endif
 

--- a/display/lcd/esp_lcd_dsi/test_apps/CMakeLists.txt
+++ b/display/lcd/esp_lcd_dsi/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_dsi)

--- a/display/lcd/esp_lcd_dsi/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_dsi/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_dsi.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_dsi.c"
+                       REQUIRES esp_lcd_dsi esp_lcd ${DRIVER_REQ} esp_hw_support esp_timer unity)

--- a/display/lcd/esp_lcd_dsi/test_apps/main/test_esp_lcd_dsi.c
+++ b/display/lcd/esp_lcd_dsi/test_apps/main/test_esp_lcd_dsi.c
@@ -5,7 +5,6 @@
 #include <inttypes.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_hi8561/CMakeLists.txt
+++ b/display/lcd/esp_lcd_hi8561/CMakeLists.txt
@@ -1,6 +1,13 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS "esp_lcd_hi8561.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES "esp_lcd")
+                       REQUIRES "esp_lcd"
+                       PRIV_REQUIRES ${PRIV_REQ})
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_hi8561/idf_component.yml
+++ b/display/lcd/esp_lcd_hi8561/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.0.2"
+version: 2.0.0
 license: "MIT"
 targets:
   - esp32p4

--- a/display/lcd/esp_lcd_hi8561/include/esp_lcd_hi8561.h
+++ b/display/lcd/esp_lcd_hi8561/include/esp_lcd_hi8561.h
@@ -148,6 +148,19 @@ esp_err_t esp_lcd_new_panel_hi8561(const esp_lcd_panel_io_handle_t io, const esp
         },                                               \
     }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define HI8561_540_1168_PANEL_60HZ_DPI_CONFIG(color_format) HI8561_540_1168_PANEL_60HZ_DPI_CONFIG_CF(color_format)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/display/lcd/esp_lcd_hi8561/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_hi8561/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_hi8561.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_hi8561.c"
+                       REQUIRES esp_lcd_hi8561 esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/lcd/esp_lcd_hi8561/test_apps/main/test_esp_lcd_hi8561.c
+++ b/display/lcd/esp_lcd_hi8561/test_apps/main/test_esp_lcd_hi8561.c
@@ -12,7 +12,6 @@
 #include <inttypes.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"
@@ -259,9 +258,9 @@ void app_main(void)
 	 */
     printf("  _   _   ___    ___    ____     __     _ \r\n");
     printf(" | | | | |_ _|  ( _ )  | ___|   / /_   / |\r\n");
-    printf(" | |_| |  | |   / _ \  |___ \  | '_ \  | |\r\n");
+    printf(" | |_| |  | |   / _ \\  |___ \\  | '_ \\  | |\r\n");
     printf(" |  _  |  | |  | (_) |  ___) | | (_) | | |\r\n");
-    printf(" |_| |_| |___|  \___/  |____/   \___/  |_|\r\n");
+    printf(" |_| |_| |___|  \\___/  |____/   \\___/  |_|\r\n");
     unity_run_menu();
 }
 #endif

--- a/display/lcd/esp_lcd_hx8394/CMakeLists.txt
+++ b/display/lcd/esp_lcd_hx8394/CMakeLists.txt
@@ -1,7 +1,13 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS "esp_lcd_hx8394.c"
                        INCLUDE_DIRS "include"
                        REQUIRES "esp_lcd"
-                       PRIV_REQUIRES "esp_driver_gpio")
+                       PRIV_REQUIRES ${PRIV_REQ})
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_hx8394/esp_lcd_hx8394.c
+++ b/display/lcd/esp_lcd_hx8394/esp_lcd_hx8394.c
@@ -12,6 +12,7 @@
 #include "freertos/task.h"
 #include "driver/gpio.h"
 #include "esp_lcd_hx8394.h"
+#include "esp_idf_version.h"
 #include "i2c_bus.h"
 
 #define HX8394_CMD_DSI_INT0 (0xBA)
@@ -69,7 +70,7 @@ esp_err_t esp_lcd_new_panel_hx8394(const esp_lcd_panel_io_handle_t io, const esp
         ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
     }
 
-    switch (panel_dev_config->color_space)
+    switch (panel_dev_config->rgb_ele_order)
     {
     case LCD_RGB_ELEMENT_ORDER_RGB:
         hx8394->madctl_val = 0;
@@ -136,6 +137,9 @@ esp_err_t esp_lcd_new_panel_hx8394(const esp_lcd_panel_io_handle_t io, const esp
     esp_lcd_panel_handle_t panel_handle = NULL;
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_dpi(vendor_config->mipi_config.dsi_bus, vendor_config->mipi_config.dpi_config, &panel_handle), err, TAG,
                       "create MIPI DPI panel failed");
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ESP_GOTO_ON_ERROR(esp_lcd_dpi_panel_enable_dma2d(panel_handle), err, TAG, "enable MIPI DPI DMA2D failed");
+#endif
     ESP_LOGD(TAG, "new MIPI DPI panel @%p", panel_handle);
 
     // Save the original functions of MIPI DPI panel

--- a/display/lcd/esp_lcd_hx8394/idf_component.yml
+++ b/display/lcd/esp_lcd_hx8394/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "2.0.0"
 license: "MIT"
 targets:
   - esp32p4

--- a/display/lcd/esp_lcd_hx8394/include/esp_lcd_hx8394.h
+++ b/display/lcd/esp_lcd_hx8394/include/esp_lcd_hx8394.h
@@ -6,6 +6,26 @@
 #if SOC_MIPI_DSI_SUPPORTED
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_mipi_dsi.h"
+#include "esp_idf_version.h"
+
+#ifndef WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .in_color_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D
+#else
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .pixel_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D .flags.use_dma2d = true,
+#endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -92,7 +112,7 @@ esp_err_t esp_lcd_new_panel_hx8394(const esp_lcd_panel_io_handle_t io, const esp
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,             \
         .dpi_clock_freq_mhz = 58,                                \
         .virtual_channel = 0,                                    \
-        .pixel_format = px_format,                               \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format),                               \
         .num_fbs = 1,                                            \
         .video_timing = {                                        \
             .h_size = 720,                                      \
@@ -104,7 +124,7 @@ esp_err_t esp_lcd_new_panel_hx8394(const esp_lcd_panel_io_handle_t io, const esp
             .vsync_pulse_width = 4,                              \
             .vsync_front_porch = 24,                             \
         },                                                       \
-        .flags.use_dma2d = true,                                 \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                                 \
     }
 #endif
 

--- a/display/lcd/esp_lcd_hx8394/test_apps/CMakeLists.txt
+++ b/display/lcd/esp_lcd_hx8394/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_hx8394)

--- a/display/lcd/esp_lcd_hx8394/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_hx8394/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_hx8394.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_hx8394.c"
+                       REQUIRES esp_lcd_hx8394 esp_lcd ${DRIVER_REQ} esp_hw_support esp_timer unity)

--- a/display/lcd/esp_lcd_hx8394/test_apps/main/test_esp_lcd_hx8394.c
+++ b/display/lcd/esp_lcd_hx8394/test_apps/main/test_esp_lcd_hx8394.c
@@ -5,7 +5,6 @@
 #include <inttypes.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_ili9881c/CMakeLists.txt
+++ b/display/lcd/esp_lcd_ili9881c/CMakeLists.txt
@@ -3,7 +3,13 @@ if(CONFIG_SOC_MIPI_DSI_SUPPORTED)
     list(APPEND srcs "esp_lcd_ili9881c.c")
 endif()
 
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"
                        REQUIRES "esp_lcd"
-                       PRIV_REQUIRES "esp_driver_gpio")
+                       PRIV_REQUIRES ${PRIV_REQ})

--- a/display/lcd/esp_lcd_ili9881c/esp_lcd_ili9881c.c
+++ b/display/lcd/esp_lcd_ili9881c/esp_lcd_ili9881c.c
@@ -18,6 +18,7 @@
 #include "freertos/task.h"
 #include "driver/gpio.h"
 #include "esp_lcd_ili9881c.h"
+#include "esp_idf_version.h"
 
 #include "i2c_bus.h"
 
@@ -152,6 +153,9 @@ esp_err_t esp_lcd_new_panel_ili9881c(const esp_lcd_panel_io_handle_t io, const e
     // Create MIPI DPI panel
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_dpi(vendor_config->mipi_config.dsi_bus, vendor_config->mipi_config.dpi_config, ret_panel), err, TAG,
                       "create MIPI DPI panel failed");
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ESP_GOTO_ON_ERROR(esp_lcd_dpi_panel_enable_dma2d(*ret_panel), err, TAG, "enable MIPI DPI DMA2D failed");
+#endif
     ESP_LOGD(TAG, "new MIPI DPI panel @%p", *ret_panel);
 
     // Save the original functions of MIPI DPI panel

--- a/display/lcd/esp_lcd_ili9881c/idf_component.yml
+++ b/display/lcd/esp_lcd_ili9881c/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.4"
+version: "2.0.0"
 targets:
   - esp32p4
 description: "Waveshare 7-DSI-TOUCH-A driver"

--- a/display/lcd/esp_lcd_ili9881c/include/esp_lcd_ili9881c.h
+++ b/display/lcd/esp_lcd_ili9881c/include/esp_lcd_ili9881c.h
@@ -16,6 +16,26 @@
 #if SOC_MIPI_DSI_SUPPORTED
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_mipi_dsi.h"
+#include "esp_idf_version.h"
+
+#ifndef WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .in_color_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D
+#else
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .pixel_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D .flags.use_dma2d = true,
+#endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -104,7 +124,7 @@ esp_err_t esp_lcd_new_panel_ili9881c(const esp_lcd_panel_io_handle_t io, const e
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,       \
         .dpi_clock_freq_mhz = 80,                          \
         .virtual_channel = 0,                              \
-        .pixel_format = px_format,                         \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format),                         \
         .num_fbs = 1,                                      \
         .video_timing = {                                  \
             .h_size = 720,                                 \
@@ -116,7 +136,7 @@ esp_err_t esp_lcd_new_panel_ili9881c(const esp_lcd_panel_io_handle_t io, const e
             .vsync_pulse_width = 30,                        \
             .vsync_front_porch = 2,                       \
         },                                                 \
-        .flags.use_dma2d = true,                           \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                           \
     }
 #endif
 

--- a/display/lcd/esp_lcd_ili9881c/test_apps/CMakeLists.txt
+++ b/display/lcd/esp_lcd_ili9881c/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_ili9881c)

--- a/display/lcd/esp_lcd_ili9881c/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_ili9881c/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_ili9881c.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_ili9881c.c"
+                       REQUIRES esp_lcd_ili9881c esp_lcd ${DRIVER_REQ} esp_hw_support esp_timer unity)

--- a/display/lcd/esp_lcd_ili9881c/test_apps/main/test_esp_lcd_ili9881c.c
+++ b/display/lcd/esp_lcd_ili9881c/test_apps/main/test_esp_lcd_ili9881c.c
@@ -10,7 +10,6 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_jd9165/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9165/CMakeLists.txt
@@ -1,6 +1,13 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS "esp_lcd_jd9165.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES "esp_lcd")
+                       REQUIRES "esp_lcd"
+                       PRIV_REQUIRES ${PRIV_REQ})
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_jd9165/esp_lcd_jd9165.c
+++ b/display/lcd/esp_lcd_jd9165/esp_lcd_jd9165.c
@@ -73,7 +73,7 @@ esp_err_t esp_lcd_new_panel_jd9165(const esp_lcd_panel_io_handle_t io, const esp
         ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
     }
 
-    switch (panel_dev_config->color_space)
+    switch (panel_dev_config->rgb_ele_order)
     {
     case LCD_RGB_ELEMENT_ORDER_RGB:
         jd9165->madctl_val = 0;

--- a/display/lcd/esp_lcd_jd9165/idf_component.yml
+++ b/display/lcd/esp_lcd_jd9165/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.2"
+version: 2.0.0
 license: "MIT"
 targets:
   - esp32p4

--- a/display/lcd/esp_lcd_jd9165/include/esp_lcd_jd9165.h
+++ b/display/lcd/esp_lcd_jd9165/include/esp_lcd_jd9165.h
@@ -12,6 +12,26 @@
 #if SOC_MIPI_DSI_SUPPORTED
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_mipi_dsi.h"
+#include "esp_idf_version.h"
+
+#ifndef WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .in_color_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D
+#else
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .pixel_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D .flags.use_dma2d = true,
+#endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -117,7 +137,7 @@ esp_err_t esp_lcd_new_panel_jd9165(const esp_lcd_panel_io_handle_t io, const esp
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 51.2,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 1024,                              \
@@ -129,7 +149,7 @@ esp_err_t esp_lcd_new_panel_jd9165(const esp_lcd_panel_io_handle_t io, const esp
             .vsync_pulse_width = 2,                      \
             .vsync_front_porch = 12,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #endif
 

--- a/display/lcd/esp_lcd_jd9165/test_apps/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9165/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_jd9165)

--- a/display/lcd/esp_lcd_jd9165/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9165/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_jd9165.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_jd9165.c"
+                       REQUIRES esp_lcd_jd9165 esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/lcd/esp_lcd_jd9165/test_apps/main/test_esp_lcd_jd9165.c
+++ b/display/lcd/esp_lcd_jd9165/test_apps/main/test_esp_lcd_jd9165.c
@@ -11,7 +11,6 @@
 #include <inttypes.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_jd9365/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9365/CMakeLists.txt
@@ -1,4 +1,13 @@
-idf_component_register(SRCS "esp_lcd_jd9365.c" INCLUDE_DIRS "include" PRIV_REQUIRES "driver" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_lcd_jd9365.c"
+                       INCLUDE_DIRS "include"
+                       REQUIRES "esp_lcd"
+                       PRIV_REQUIRES ${PRIV_REQ})
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_jd9365/esp_lcd_jd9365.c
+++ b/display/lcd/esp_lcd_jd9365/esp_lcd_jd9365.c
@@ -18,6 +18,7 @@
 #include "freertos/task.h"
 #include "driver/gpio.h"
 #include "esp_lcd_jd9365.h"
+#include "esp_idf_version.h"
 #include "i2c_bus.h"
 
 #define JD9365_CMD_PAGE (0xE0)
@@ -82,7 +83,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
         ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
     }
 
-    switch (panel_dev_config->color_space)
+    switch (panel_dev_config->rgb_ele_order)
     {
     case LCD_RGB_ELEMENT_ORDER_RGB:
         jd9365->madctl_val = 0;
@@ -149,6 +150,9 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
     esp_lcd_panel_handle_t panel_handle = NULL;
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_dpi(vendor_config->mipi_config.dsi_bus, vendor_config->mipi_config.dpi_config, &panel_handle), err, TAG,
                       "create MIPI DPI panel failed");
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ESP_GOTO_ON_ERROR(esp_lcd_dpi_panel_enable_dma2d(panel_handle), err, TAG, "enable MIPI DPI DMA2D failed");
+#endif
     ESP_LOGD(TAG, "new MIPI DPI panel @%p", panel_handle);
 
     // Save the original functions of MIPI DPI panel

--- a/display/lcd/esp_lcd_jd9365/idf_component.yml
+++ b/display/lcd/esp_lcd_jd9365/idf_component.yml
@@ -11,4 +11,4 @@ repository_info:
 targets:
 - esp32p4
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/display/lcd/esp_lcd_jd9365
-version: 1.0.6
+version: 2.0.0

--- a/display/lcd/esp_lcd_jd9365/include/esp_lcd_jd9365.h
+++ b/display/lcd/esp_lcd_jd9365/include/esp_lcd_jd9365.h
@@ -12,6 +12,26 @@
 #if SOC_MIPI_DSI_SUPPORTED
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_mipi_dsi.h"
+#include "esp_idf_version.h"
+
+#ifndef WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .in_color_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D
+#else
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .pixel_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D .flags.use_dma2d = true,
+#endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,7 +120,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 70,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format),                       \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 720,                               \
@@ -112,7 +132,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
             .vsync_pulse_width = 4,                      \
             .vsync_front_porch = 26,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                         \
     }
 
 #define JD9365_800_1280_PANEL_60HZ_DPI_CONFIG(px_format) \
@@ -120,7 +140,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format),                       \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 800,                               \
@@ -132,7 +152,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
             .vsync_pulse_width = 4,                      \
             .vsync_front_porch = 30,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                         \
     }
 
 #define JD9365_800_800_PANEL_60HZ_DPI_CONFIG(px_format) \
@@ -140,7 +160,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format),                       \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 800,                               \
@@ -152,7 +172,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
             .vsync_pulse_width = 4,                      \
             .vsync_front_porch = 24,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                         \
     }
 
 #define JD9365_720_720_PANEL_60HZ_DPI_CONFIG(px_format) \
@@ -160,7 +180,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format),                       \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 720,                               \
@@ -172,7 +192,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
             .vsync_pulse_width = 4,                      \
             .vsync_front_porch = 24,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                         \
     }
 #endif
 

--- a/display/lcd/esp_lcd_jd9365/test_apps/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9365/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_jd9365)

--- a/display/lcd/esp_lcd_jd9365/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9365/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_jd9365.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_jd9365.c"
+                       REQUIRES esp_lcd_jd9365 esp_lcd ${DRIVER_REQ} esp_hw_support esp_timer unity)

--- a/display/lcd/esp_lcd_jd9365/test_apps/main/test_esp_lcd_jd9365.c
+++ b/display/lcd/esp_lcd_jd9365/test_apps/main/test_esp_lcd_jd9365.c
@@ -8,7 +8,6 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_jd9365_10_1/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9365_10_1/CMakeLists.txt
@@ -1,4 +1,10 @@
-idf_component_register(SRCS "esp_lcd_jd9365_10_1.c" INCLUDE_DIRS "include" PRIV_REQUIRES "driver" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_lcd_jd9365_10_1.c" INCLUDE_DIRS "include" PRIV_REQUIRES ${PRIV_REQ} REQUIRES "esp_lcd")
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_jd9365_10_1/esp_lcd_jd9365_10_1.c
+++ b/display/lcd/esp_lcd_jd9365_10_1/esp_lcd_jd9365_10_1.c
@@ -85,7 +85,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
         ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
     }
 
-    switch (panel_dev_config->color_space)
+    switch (panel_dev_config->rgb_ele_order)
     {
     case LCD_RGB_ELEMENT_ORDER_RGB:
         jd9365->madctl_val = 0;

--- a/display/lcd/esp_lcd_jd9365_10_1/idf_component.yml
+++ b/display/lcd/esp_lcd_jd9365_10_1/idf_component.yml
@@ -11,4 +11,4 @@ license: "MIT"
 targets:
   - esp32p4
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/lcd/esp_lcd_jd9365_10_1"
-version: "1.0.4"
+version: 2.0.0

--- a/display/lcd/esp_lcd_jd9365_10_1/include/esp_lcd_jd9365_10_1.h
+++ b/display/lcd/esp_lcd_jd9365_10_1/include/esp_lcd_jd9365_10_1.h
@@ -12,6 +12,26 @@
 #if SOC_MIPI_DSI_SUPPORTED
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_mipi_dsi.h"
+#include "esp_idf_version.h"
+
+#ifndef WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .in_color_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D
+#else
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .pixel_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D .flags.use_dma2d = true,
+#endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -115,7 +135,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 800,                               \
@@ -127,7 +147,7 @@ esp_err_t esp_lcd_new_panel_jd9365(const esp_lcd_panel_io_handle_t io, const esp
             .vsync_pulse_width = 4,                      \
             .vsync_front_porch = 30,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #endif
 

--- a/display/lcd/esp_lcd_jd9365_10_1/test_apps/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9365_10_1/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_jd9365)

--- a/display/lcd/esp_lcd_jd9365_10_1/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9365_10_1/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_jd9365.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_jd9365.c"
+                       REQUIRES esp_lcd_jd9365_10_1 esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/lcd/esp_lcd_jd9365_10_1/test_apps/main/test_esp_lcd_jd9365.c
+++ b/display/lcd/esp_lcd_jd9365_10_1/test_apps/main/test_esp_lcd_jd9365.c
@@ -8,7 +8,6 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_jd9365_8/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9365_8/CMakeLists.txt
@@ -1,4 +1,10 @@
-idf_component_register(SRCS "esp_lcd_jd9365_8.c" INCLUDE_DIRS "include" PRIV_REQUIRES "driver" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_lcd_jd9365_8.c" INCLUDE_DIRS "include" PRIV_REQUIRES ${PRIV_REQ} REQUIRES "esp_lcd")
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_jd9365_8/esp_lcd_jd9365_8.c
+++ b/display/lcd/esp_lcd_jd9365_8/esp_lcd_jd9365_8.c
@@ -85,7 +85,7 @@ esp_err_t esp_lcd_new_panel_jd9365_8(const esp_lcd_panel_io_handle_t io, const e
         ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
     }
 
-    switch (panel_dev_config->color_space)
+    switch (panel_dev_config->rgb_ele_order)
     {
     case LCD_RGB_ELEMENT_ORDER_RGB:
         jd9365_8->madctl_val = 0;

--- a/display/lcd/esp_lcd_jd9365_8/idf_component.yml
+++ b/display/lcd/esp_lcd_jd9365_8/idf_component.yml
@@ -11,4 +11,4 @@ license: "MIT"
 targets:
   - esp32p4
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/lcd/esp_lcd_jd9365_8"
-version: "1.0.5"
+version: 2.0.0

--- a/display/lcd/esp_lcd_jd9365_8/include/esp_lcd_jd9365_8.h
+++ b/display/lcd/esp_lcd_jd9365_8/include/esp_lcd_jd9365_8.h
@@ -12,6 +12,26 @@
 #if SOC_MIPI_DSI_SUPPORTED
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_mipi_dsi.h"
+#include "esp_idf_version.h"
+
+#ifndef WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .in_color_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D
+#else
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .pixel_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D .flags.use_dma2d = true,
+#endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -115,7 +135,7 @@ esp_err_t esp_lcd_new_panel_jd9365_8(const esp_lcd_panel_io_handle_t io, const e
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 80,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format), \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 800,                               \
@@ -127,7 +147,7 @@ esp_err_t esp_lcd_new_panel_jd9365_8(const esp_lcd_panel_io_handle_t io, const e
             .vsync_pulse_width = 4,                      \
             .vsync_front_porch = 30,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                   \
     }
 #endif
 

--- a/display/lcd/esp_lcd_jd9365_8/test_apps/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9365_8/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_jd9365)

--- a/display/lcd/esp_lcd_jd9365_8/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_jd9365_8/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_jd9365.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_jd9365.c"
+                       REQUIRES esp_lcd_jd9365_8 esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/lcd/esp_lcd_jd9365_8/test_apps/main/test_esp_lcd_jd9365.c
+++ b/display/lcd/esp_lcd_jd9365_8/test_apps/main/test_esp_lcd_jd9365.c
@@ -8,7 +8,6 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_ota7290b/CMakeLists.txt
+++ b/display/lcd/esp_lcd_ota7290b/CMakeLists.txt
@@ -1,6 +1,13 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS "esp_lcd_ota7290b.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES "esp_lcd")
+                       REQUIRES "esp_lcd"
+                       PRIV_REQUIRES ${PRIV_REQ})
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_ota7290b/esp_lcd_ota7290b.c
+++ b/display/lcd/esp_lcd_ota7290b/esp_lcd_ota7290b.c
@@ -18,6 +18,7 @@
 #include "freertos/task.h"
 #include "driver/gpio.h"
 #include "esp_lcd_ota7290b.h"
+#include "esp_idf_version.h"
 #include "i2c_bus.h"
 
 typedef struct {
@@ -114,6 +115,9 @@ esp_err_t esp_lcd_new_panel_ota7290b(const esp_lcd_panel_io_handle_t io, const e
     esp_lcd_panel_handle_t panel_handle = NULL;
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_dpi(vendor_config->mipi_config.dsi_bus, vendor_config->mipi_config.dpi_config, &panel_handle), err, TAG,
                       "create MIPI DPI panel failed");
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ESP_GOTO_ON_ERROR(esp_lcd_dpi_panel_enable_dma2d(panel_handle), err, TAG, "enable MIPI DPI DMA2D failed");
+#endif
     ESP_LOGD(TAG, "new MIPI DPI panel @%p", panel_handle);
 
     // Save the original functions of MIPI DPI panel

--- a/display/lcd/esp_lcd_ota7290b/idf_component.yml
+++ b/display/lcd/esp_lcd_ota7290b/idf_component.yml
@@ -8,4 +8,4 @@ targets:
 - esp32p4
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/lcd/esp_lcd_ota7290b"
 issues: "https://github.com/waveshareteam/Waveshare-ESP32-components/issues"
-version: 1.0.0
+version: 2.0.0

--- a/display/lcd/esp_lcd_ota7290b/include/esp_lcd_ota7290b.h
+++ b/display/lcd/esp_lcd_ota7290b/include/esp_lcd_ota7290b.h
@@ -14,6 +14,25 @@
 #include "esp_lcd_mipi_dsi.h"
 #include "esp_idf_version.h"
 
+#ifndef WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .in_color_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D
+#else
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .pixel_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D .flags.use_dma2d = true,
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -89,7 +108,6 @@ esp_err_t esp_lcd_new_panel_ota7290b(const esp_lcd_panel_io_handle_t io, const e
         .lcd_param_bits = 8,          \
     }
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
 /**
  * @brief MIPI DPI configuration structure
  *
@@ -104,7 +122,7 @@ esp_err_t esp_lcd_new_panel_ota7290b(const esp_lcd_panel_io_handle_t io, const e
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,     \
         .dpi_clock_freq_mhz = 75,                        \
         .virtual_channel = 0,                            \
-        .pixel_format = px_format,                       \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format),                       \
         .num_fbs = 1,                                    \
         .video_timing = {                                \
             .h_size = 480,                              \
@@ -116,9 +134,8 @@ esp_err_t esp_lcd_new_panel_ota7290b(const esp_lcd_panel_io_handle_t io, const e
             .vsync_pulse_width = 20,                      \
             .vsync_front_porch = 20,                     \
         },                                               \
-        .flags.use_dma2d = true,                         \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                         \
     }
-#endif
 
 /**
  * @brief MIPI DPI configuration structure

--- a/display/lcd/esp_lcd_ota7290b/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_ota7290b/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_ota7290b.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_ota7290b.c"
+                       REQUIRES esp_lcd_ota7290b esp_lcd ${DRIVER_REQ} esp_hw_support esp_timer unity)

--- a/display/lcd/esp_lcd_ota7290b/test_apps/main/test_esp_lcd_ota7290b.c
+++ b/display/lcd/esp_lcd_ota7290b/test_apps/main/test_esp_lcd_ota7290b.c
@@ -11,7 +11,6 @@
 #include <inttypes.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_sd5207/CMakeLists.txt
+++ b/display/lcd/esp_lcd_sd5207/CMakeLists.txt
@@ -1,6 +1,13 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS "esp_lcd_sd5207.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES "esp_lcd")
+                       REQUIRES "esp_lcd"
+                       PRIV_REQUIRES ${PRIV_REQ})
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_sd5207/idf_component.yml
+++ b/display/lcd/esp_lcd_sd5207/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.0.2"
+version: 2.0.0
 license: "MIT"
 targets:
   - esp32p4

--- a/display/lcd/esp_lcd_sd5207/include/esp_lcd_sd5207.h
+++ b/display/lcd/esp_lcd_sd5207/include/esp_lcd_sd5207.h
@@ -149,6 +149,19 @@ esp_err_t esp_lcd_new_panel_sd5207(const esp_lcd_panel_io_handle_t io, const esp
         },                                               \
     }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define SD5207_568_1210_PANEL_60HZ_DPI_CONFIG(color_format) SD5207_568_1210_PANEL_60HZ_DPI_CONFIG_CF(color_format)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/display/lcd/esp_lcd_sd5207/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_sd5207/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_sd5207.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_sd5207.c"
+                       REQUIRES esp_lcd_sd5207 esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/lcd/esp_lcd_sd5207/test_apps/main/test_esp_lcd_sd5207.c
+++ b/display/lcd/esp_lcd_sd5207/test_apps/main/test_esp_lcd_sd5207.c
@@ -12,7 +12,6 @@
 #include <inttypes.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_sh8601/CMakeLists.txt
+++ b/display/lcd/esp_lcd_sh8601/CMakeLists.txt
@@ -1,4 +1,10 @@
-idf_component_register(SRCS "esp_lcd_sh8601.c" INCLUDE_DIRS "include" PRIV_REQUIRES "driver" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_lcd_sh8601.c" INCLUDE_DIRS "include" PRIV_REQUIRES ${PRIV_REQ} REQUIRES "esp_lcd")
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_sh8601/idf_component.yml
+++ b/display/lcd/esp_lcd_sh8601/idf_component.yml
@@ -6,4 +6,4 @@ dependencies:
 description: "ESP LCD FOR Waveshare ESP32-S3-Touch-AMOLED-1.8 DISPLAY SH8601"
 issues: "https://github.com/waveshareteam/Waveshare-ESP32-components/issues"
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/lcd/esp_lcd_sh8601"
-version: "1.0.2"
+version: 2.0.0

--- a/display/lcd/esp_lcd_sh8601/test_apps/CMakeLists.txt
+++ b/display/lcd/esp_lcd_sh8601/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_gc9b71)

--- a/display/lcd/esp_lcd_sh8601/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_sh8601/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_sh8601.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_sh8601.c"
+                       REQUIRES esp_lcd_sh8601 esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/lcd/esp_lcd_sh8601/test_apps/main/test_esp_lcd_sh8601.c
+++ b/display/lcd/esp_lcd_sh8601/test_apps/main/test_esp_lcd_sh8601.c
@@ -13,6 +13,7 @@
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
+#include "esp_lcd_panel_io.h"
 #include "esp_lcd_panel_io_interface.h"
 #include "esp_lcd_panel_ops.h"
 #include "unity.h"
@@ -198,11 +199,5 @@ void app_main(void)
     printf("\\ \\  / /_/ / _ \\| '_ \\| | | | |\r\n");
     printf("_\\ \\/ __  / (_) | (_) | |_| | |\r\n");
     printf("\\__/\\/ /_/ \\___/ \\___/ \\___/|_|\r\n");
-    // unity_run_menu();
-
-    ESP_LOGI(TAG, "Initialize LCD device");
-    test_init_lcd();
-
-    ESP_LOGI(TAG, "Show color bar pattern drawn by hardware");
-    TEST_ESP_OK(esp_lcd_dpi_panel_set_pattern(panel_handle, MIPI_DSI_PATTERN_BAR_VERTICAL));
+    unity_run_menu();
 }

--- a/display/lcd/esp_lcd_st7703/CMakeLists.txt
+++ b/display/lcd/esp_lcd_st7703/CMakeLists.txt
@@ -1,6 +1,13 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS "esp_lcd_st7703.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES "esp_lcd")
+                       REQUIRES "esp_lcd"
+                       PRIV_REQUIRES ${PRIV_REQ})
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/display/lcd/esp_lcd_st7703/esp_lcd_st7703.c
+++ b/display/lcd/esp_lcd_st7703/esp_lcd_st7703.c
@@ -18,6 +18,7 @@
 #include "freertos/task.h"
 #include "driver/gpio.h"
 #include "esp_lcd_st7703.h"
+#include "esp_idf_version.h"
 
 typedef struct
 {
@@ -70,7 +71,7 @@ esp_err_t esp_lcd_new_panel_st7703(const esp_lcd_panel_io_handle_t io, const esp
         ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
     }
 
-    switch (panel_dev_config->color_space)
+    switch (panel_dev_config->rgb_ele_order)
     {
     case LCD_RGB_ELEMENT_ORDER_RGB:
         st7703->madctl_val = 0;
@@ -93,6 +94,9 @@ esp_err_t esp_lcd_new_panel_st7703(const esp_lcd_panel_io_handle_t io, const esp
     esp_lcd_panel_handle_t panel_handle = NULL;
     ESP_GOTO_ON_ERROR(esp_lcd_new_panel_dpi(vendor_config->mipi_config.dsi_bus, vendor_config->mipi_config.dpi_config, &panel_handle), err, TAG,
                       "create MIPI DPI panel failed");
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ESP_GOTO_ON_ERROR(esp_lcd_dpi_panel_enable_dma2d(panel_handle), err, TAG, "enable MIPI DPI DMA2D failed");
+#endif
     ESP_LOGD(TAG, "new MIPI DPI panel @%p", panel_handle);
 
     // Save the original functions of MIPI DPI panel

--- a/display/lcd/esp_lcd_st7703/idf_component.yml
+++ b/display/lcd/esp_lcd_st7703/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.5"
+version: "2.0.0"
 license: "MIT"
 targets:
   - esp32p4

--- a/display/lcd/esp_lcd_st7703/include/esp_lcd_st7703.h
+++ b/display/lcd/esp_lcd_st7703/include/esp_lcd_st7703.h
@@ -12,6 +12,26 @@
 #if SOC_MIPI_DSI_SUPPORTED
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_mipi_dsi.h"
+#include "esp_idf_version.h"
+
+#ifndef WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB565
+#define LCD_COLOR_PIXEL_FORMAT_RGB565 LCD_COLOR_FMT_RGB565
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB666
+#define LCD_COLOR_PIXEL_FORMAT_RGB666 LCD_COLOR_FMT_RGB888
+#endif
+#ifndef LCD_COLOR_PIXEL_FORMAT_RGB888
+#define LCD_COLOR_PIXEL_FORMAT_RGB888 LCD_COLOR_FMT_RGB888
+#endif
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .in_color_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D
+#else
+#define WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format) .pixel_format = px_format
+#define WAVESHARE_LCD_DPI_CONFIG_DMA2D .flags.use_dma2d = true,
+#endif
+#endif
 
 #ifdef __cplusplus
 extern "C"
@@ -123,7 +143,7 @@ extern "C"
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,    \
         .dpi_clock_freq_mhz = 38,                       \
         .virtual_channel = 0,                           \
-        .pixel_format = px_format,                      \
+        WAVESHARE_LCD_DPI_CONFIG_COLOR_FORMAT(px_format),                      \
         .num_fbs = 1,                                   \
         .video_timing = {                               \
             .h_size = 720,                              \
@@ -135,7 +155,7 @@ extern "C"
             .vsync_pulse_width = 4,                     \
             .vsync_front_porch = 20,                    \
         },                                              \
-        .flags.use_dma2d = true,                        \
+        WAVESHARE_LCD_DPI_CONFIG_DMA2D                        \
     }
 #endif
 

--- a/display/lcd/esp_lcd_st7703/test_apps/CMakeLists.txt
+++ b/display/lcd/esp_lcd_st7703/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_st7703)

--- a/display/lcd/esp_lcd_st7703/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_st7703/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_st7703.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_st7703.c"
+                       REQUIRES esp_lcd_st7703 esp_lcd ${DRIVER_REQ} esp_hw_support esp_timer unity)

--- a/display/lcd/esp_lcd_st7703/test_apps/main/test_esp_lcd_st7703.c
+++ b/display/lcd/esp_lcd_st7703/test_apps/main/test_esp_lcd_st7703.c
@@ -11,7 +11,6 @@
 #include <inttypes.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/i2c.h"
 #include "driver/spi_master.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"

--- a/display/lcd/esp_lcd_st7735/CMakeLists.txt
+++ b/display/lcd/esp_lcd_st7735/CMakeLists.txt
@@ -1,5 +1,11 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
 idf_component_register(SRCS "esp_lcd_st7735.c"
                        INCLUDE_DIRS "include"
                        REQUIRES "esp_lcd"
-                       PRIV_REQUIRES "driver")
+                       PRIV_REQUIRES ${PRIV_REQ})
 

--- a/display/lcd/esp_lcd_st7735/esp_lcd_st7735.c
+++ b/display/lcd/esp_lcd_st7735/esp_lcd_st7735.c
@@ -57,12 +57,12 @@ esp_err_t esp_lcd_new_panel_st7735(const esp_lcd_panel_io_handle_t io, const esp
         ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, TAG, "configure GPIO for RST line failed");
     }
 
-    switch (panel_dev_config->rgb_endian)
+    switch (panel_dev_config->rgb_ele_order)
     {
-    case LCD_RGB_ENDIAN_RGB:
+    case LCD_RGB_ELEMENT_ORDER_RGB:
         st7735->madctl_val = 0;
         break;
-    case LCD_RGB_ENDIAN_BGR:
+    case LCD_RGB_ELEMENT_ORDER_BGR:
         st7735->madctl_val |= LCD_CMD_BGR_BIT;
         break;
     default:

--- a/display/lcd/esp_lcd_st7735/idf_component.yml
+++ b/display/lcd/esp_lcd_st7735/idf_component.yml
@@ -1,3 +1,3 @@
 description: ESP-LCD ST7735 component for ESP-IDF
 license: MIT
-version: 1.0.1
+version: 2.0.0

--- a/display/lcd/esp_lcd_st7735/test_apps/main/CMakeLists.txt
+++ b/display/lcd/esp_lcd_st7735/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_st7735.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_st7735.c"
+                       REQUIRES esp_lcd_st7735 esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/lcd/esp_lcd_st7735/test_apps/main/test_esp_lcd_st7735.c
+++ b/display/lcd/esp_lcd_st7735/test_apps/main/test_esp_lcd_st7735.c
@@ -5,8 +5,11 @@
  */
 
 #include "esp_err.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "driver/gpio.h"
 #include "driver/spi_master.h"
+#include "esp_heap_caps.h"
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_panel_ops.h"
@@ -141,7 +144,7 @@ esp_err_t lcd_init(void)
     ESP_LOGD(TAG, "Install ST7735 panel driver");
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = LCD_GPIO_RST,
-        .color_space = LCD_RGB_ELEMENT_ORDER_BGR,
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_BGR,
         .bits_per_pixel = LCD_BITS_PER_PIXEL,
         // .vendor_config =&vendor_config,
     };

--- a/display/oled/esp_oled_ssd1309/CMakeLists.txt
+++ b/display/oled/esp_oled_ssd1309/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "esp_oled_ssd1309.c" INCLUDE_DIRS "include" PRIV_REQUIRES "driver" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_oled_ssd1309.c" INCLUDE_DIRS "include" PRIV_REQUIRES ${PRIV_REQ} REQUIRES "esp_lcd")

--- a/display/oled/esp_oled_ssd1309/idf_component.yml
+++ b/display/oled/esp_oled_ssd1309/idf_component.yml
@@ -8,4 +8,4 @@ repository_info:
   commit_sha: 3375617c3eba80466945ccc7849706dac256111d
   path: display/oled/esp_oled_ssd1309
 url: https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/oled/esp_oled_ssd1309
-version: 1.0.2
+version: 2.0.0

--- a/display/oled/esp_oled_ssd1309/test_apps/CMakeLists.txt
+++ b/display/oled/esp_oled_ssd1309/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_oled_ssd1309)

--- a/display/oled/esp_oled_ssd1309/test_apps/main/CMakeLists.txt
+++ b/display/oled/esp_oled_ssd1309/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_oled_ssd1309.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_i2c)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_oled_ssd1309.c"
+                       REQUIRES esp_oled_ssd1309 esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/oled/esp_oled_ssd1315/CMakeLists.txt
+++ b/display/oled/esp_oled_ssd1315/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "esp_oled_ssd1315.c" INCLUDE_DIRS "include" PRIV_REQUIRES "driver" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_oled_ssd1315.c" INCLUDE_DIRS "include" PRIV_REQUIRES ${PRIV_REQ} REQUIRES "esp_lcd")

--- a/display/oled/esp_oled_ssd1315/idf_component.yml
+++ b/display/oled/esp_oled_ssd1315/idf_component.yml
@@ -8,4 +8,4 @@ repository_info:
   commit_sha: 310ccc681289046194f6a1aa7489bf157761888b
   path: display/oled/esp_oled_ssd1315
 url: https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/oled/esp_oled_ssd1315
-version: 1.0.1
+version: 2.0.0

--- a/display/oled/esp_oled_ssd1315/test_apps/CMakeLists.txt
+++ b/display/oled/esp_oled_ssd1315/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_oled_ssd1315)

--- a/display/oled/esp_oled_ssd1315/test_apps/main/CMakeLists.txt
+++ b/display/oled/esp_oled_ssd1315/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_oled_ssd1315.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_i2c)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_oled_ssd1315.c"
+                       REQUIRES esp_oled_ssd1315 esp_lcd ${DRIVER_REQ} esp_timer unity)

--- a/display/touch/esp_lcd_touch_axs15260d/CMakeLists.txt
+++ b/display/touch/esp_lcd_touch_axs15260d/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "esp_lcd_touch_axs15260d.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio esp_driver_i2c)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_axs15260d.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd" PRIV_REQUIRES ${PRIV_REQ})

--- a/display/touch/esp_lcd_touch_axs15260d/esp_lcd_touch_axs15260d.c
+++ b/display/touch/esp_lcd_touch_axs15260d/esp_lcd_touch_axs15260d.c
@@ -7,7 +7,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include "driver/i2c.h"
 #include "driver/i2c_master.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/display/touch/esp_lcd_touch_axs15260d/idf_component.yml
+++ b/display/touch/esp_lcd_touch_axs15260d/idf_component.yml
@@ -5,4 +5,4 @@ dependencies:
   idf: '>=4.4.2'
 description: "ESP LCD Touch AXS15260D -The touch controller AXS15260D is adapted by waveshare"
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/touch/esp_lcd_touch_axs15260d"
-version: "0.0.2"
+version: 1.0.0

--- a/display/touch/esp_lcd_touch_cst328/CMakeLists.txt
+++ b/display/touch/esp_lcd_touch_cst328/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "esp_lcd_touch_cst328.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio esp_driver_i2c)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_cst328.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd" PRIV_REQUIRES ${PRIV_REQ})

--- a/display/touch/esp_lcd_touch_cst328/idf_component.yml
+++ b/display/touch/esp_lcd_touch_cst328/idf_component.yml
@@ -5,4 +5,4 @@ dependencies:
   idf: '>=4.4.2'
 description: "ESP LCD Touch CST328 -The touch controller CST328 is adapted by waveshare"
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/touch/esp_lcd_touch_cst328"
-version: "1.0.4"
+version: 2.0.0

--- a/display/touch/esp_lcd_touch_cst328/test_apps/CMakeLists.txt
+++ b/display/touch/esp_lcd_touch_cst328/test_apps/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
+set(unit_test_app_components "$ENV{IDF_PATH}/tools/unit-test-app/components")
+if(EXISTS "${unit_test_app_components}")
+    set(EXTRA_COMPONENT_DIRS "${unit_test_app_components}")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test_esp_lcd_touch_cst328)

--- a/display/touch/esp_lcd_touch_cst328/test_apps/main/CMakeLists.txt
+++ b/display/touch/esp_lcd_touch_cst328/test_apps/main/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "test_esp_lcd_touch_cst328.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_i2c)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
+idf_component_register(SRCS "test_esp_lcd_touch_cst328.c"
+                       REQUIRES esp_lcd_touch_cst328 ${DRIVER_REQ} esp_timer unity)

--- a/display/touch/esp_lcd_touch_cst328/test_apps/main/test_esp_lcd_touch_cst328.c
+++ b/display/touch/esp_lcd_touch_cst328/test_apps/main/test_esp_lcd_touch_cst328.c
@@ -1,12 +1,15 @@
 #include "esp_lcd_touch_cst328.h"
 
-#include "lcd_driver.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "driver/i2c_master.h"
-#include "lcd_driver.h"
 #include "esp_log.h"
+#include "esp_lcd_panel_ops.h"
 
 
 // Pinout配置（保持原定义）
+#define EXAMPLE_LCD_H_RES  240
+#define EXAMPLE_LCD_V_RES  320
 #define I2C_MASTER_SCL_IO   1          /*!< I2C时钟引脚 */
 #define I2C_MASTER_SDA_IO   0          /*!< I2C数据引脚 */
 #define I2C_MASTER_NUM      I2C_NUM_0   /*!< I2C端口号 */
@@ -20,6 +23,7 @@ static const char *TAG = "Touch Example";
 esp_lcd_touch_handle_t tp_handle = NULL;
 esp_lcd_panel_io_handle_t tp_io_handle = NULL;
 i2c_master_bus_handle_t i2c_handle = NULL;
+static esp_lcd_panel_handle_t panel_handle = NULL;
 bool touch_test_done = false;
 
 
@@ -39,8 +43,7 @@ void touch_init(void)
     }
     ESP_LOGI(TAG, "I2C bus sucessfull");
 
-        i2c_master_bus_handle_t i2c_handle;
-    i2c_master_get_bus_handle(0,&i2c_handle);
+    i2c_master_get_bus_handle(0, &i2c_handle);
     esp_lcd_touch_config_t tp_cfg = {
         .x_max = EXAMPLE_LCD_H_RES,
         .y_max = EXAMPLE_LCD_V_RES,
@@ -101,7 +104,7 @@ void touch_test(void)
 
 }
 
-void void app_main(void)
+void app_main(void)
 {
     touch_init();
     //lcd _init();

--- a/display/touch/esp_lcd_touch_cst3530/CMakeLists.txt
+++ b/display/touch/esp_lcd_touch_cst3530/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "esp_lcd_touch_cst3530.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio esp_driver_i2c)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_cst3530.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd" PRIV_REQUIRES ${PRIV_REQ})

--- a/display/touch/esp_lcd_touch_cst3530/idf_component.yml
+++ b/display/touch/esp_lcd_touch_cst3530/idf_component.yml
@@ -5,4 +5,4 @@ dependencies:
   idf: '>=4.4.2'
 description: "ESP LCD Touch CST3530 -The touch controller CST3530 is adapted by waveshare"
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/touch/esp_lcd_touch_cst3530"
-version: "0.0.2"
+version: 1.0.0

--- a/display/touch/esp_lcd_touch_cst9217/CMakeLists.txt
+++ b/display/touch/esp_lcd_touch_cst9217/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "esp_lcd_touch_cst9217.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio esp_driver_i2c)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_cst9217.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd" PRIV_REQUIRES ${PRIV_REQ})

--- a/display/touch/esp_lcd_touch_cst9217/idf_component.yml
+++ b/display/touch/esp_lcd_touch_cst9217/idf_component.yml
@@ -5,4 +5,4 @@ dependencies:
   idf: '>=4.4.2'
 description: "ESP LCD Touch CST9217 -The touch controller CST9217 is adapted by waveshare"
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/touch/esp_lcd_touch_cst9217"
-version: "1.0.4"
+version: 2.0.0

--- a/display/touch/esp_lcd_touch_hi8561/CMakeLists.txt
+++ b/display/touch/esp_lcd_touch_hi8561/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "esp_lcd_touch_hi8561.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(PRIV_REQ esp_driver_gpio esp_driver_i2c)
+else()
+    set(PRIV_REQ driver)
+endif()
+
+idf_component_register(SRCS "esp_lcd_touch_hi8561.c" INCLUDE_DIRS "include" REQUIRES "esp_lcd" PRIV_REQUIRES ${PRIV_REQ})

--- a/display/touch/esp_lcd_touch_hi8561/esp_lcd_touch_hi8561.c
+++ b/display/touch/esp_lcd_touch_hi8561/esp_lcd_touch_hi8561.c
@@ -7,7 +7,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include "driver/i2c.h"
 #include "driver/i2c_master.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/display/touch/esp_lcd_touch_hi8561/idf_component.yml
+++ b/display/touch/esp_lcd_touch_hi8561/idf_component.yml
@@ -5,4 +5,4 @@ dependencies:
   idf: '>=4.4.2'
 description: "ESP LCD Touch HI8561 -The touch controller HI8561 is adapted by waveshare"
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/display/touch/esp_lcd_touch_hi8561"
-version: "0.0.1"
+version: 1.0.0

--- a/lora/esp_lora_1121/CMakeLists.txt
+++ b/lora/esp_lora_1121/CMakeLists.txt
@@ -18,3 +18,7 @@ idf_component_register(
     INCLUDE_DIRS ${INCLUDE_DIRS}
     REQUIRES esp_timer esp_driver_i2c esp_driver_spi esp_driver_gpio
 )
+
+if(${IDF_VERSION_MAJOR} GREATER_EQUAL 6)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE LR11XX_DISABLE_WARNINGS)
+endif()

--- a/lora/esp_lora_1121/idf_component.yml
+++ b/lora/esp_lora_1121/idf_component.yml
@@ -3,4 +3,4 @@ dependencies:
     version: '>=5.3.0'
 
 description: Board Support Package for LoRa 1121
-version: 1.0.0
+version: 2.0.0

--- a/lora/esp_lora_1121/include/lr1121_common/lr1121_common.h
+++ b/lora/esp_lora_1121/include/lr1121_common/lr1121_common.h
@@ -127,7 +127,7 @@ const smtc_shield_lr11xx_lfclk_cfg_t* smtc_shield_lr11xx_common_get_lfclk_cfg( v
 const smtc_shield_lr11xx_pa_pwr_cfg_t* smtc_shield_lr1121mb1gis_get_pa_pwr_cfg( const uint32_t rf_freq_in_hz,
     int8_t expected_output_pwr_in_dbm );
 
-const uint8_t smtc_shield_lr11xx_common_compute_lora_ldro( const lr11xx_radio_lora_sf_t sf, const lr11xx_radio_lora_bw_t bw );
+uint8_t smtc_shield_lr11xx_common_compute_lora_ldro( const lr11xx_radio_lora_sf_t sf, const lr11xx_radio_lora_bw_t bw );
 
 /*!
  * \brief Given the length of a BPSK frame, in bits, calculate the space necessary to hold the frame after differential

--- a/lora/esp_lora_1121/src/esp_lora_1121.c
+++ b/lora/esp_lora_1121/src/esp_lora_1121.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include "esp_lora_1121.h"
 
 
@@ -47,7 +48,7 @@ void lora_init_irq(const void *context, gpio_isr_t handler)
     gpio_install_isr_service(0); // Pass 0 for default ISR flags
 
     // Register the interrupt handler for the specified pin
-    gpio_isr_handler_add(((lr1121_t *)context)->irq, handler, (void *)((lr1121_t *)context)->irq);
+    gpio_isr_handler_add(((lr1121_t *)context)->irq, handler, (void *)(intptr_t)((lr1121_t *)context)->irq);
 }
 
 void lora_spi_init(const void* context, spi_device_handle_t spi)

--- a/lora/esp_lora_1121/src/lr1121_common/lr1121_common.c
+++ b/lora/esp_lora_1121/src/lr1121_common/lr1121_common.c
@@ -766,7 +766,7 @@ const smtc_shield_lr11xx_pa_pwr_cfg_t* smtc_shield_lr1121mb1gis_get_pa_pwr_cfg( 
  * @param [in] sf  LoRa Spreading Factor
  * @param [in] bw  LoRa Bandwidth
  */
-const uint8_t smtc_shield_lr11xx_common_compute_lora_ldro( const lr11xx_radio_lora_sf_t sf, const lr11xx_radio_lora_bw_t bw )
+uint8_t smtc_shield_lr11xx_common_compute_lora_ldro( const lr11xx_radio_lora_sf_t sf, const lr11xx_radio_lora_bw_t bw )
 {
     switch( bw )
     {

--- a/lora/esp_lora_1121/src/lr1121_modem_hal.c
+++ b/lora/esp_lora_1121/src/lr1121_modem_hal.c
@@ -39,6 +39,8 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "esp_lora_1121.h"
 
 /*!

--- a/lora/esp_lora_1121/src/lr11xx_hal.c
+++ b/lora/esp_lora_1121/src/lr11xx_hal.c
@@ -39,6 +39,8 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "esp_lora_1121.h"
 
 /*!

--- a/lora/esp_lora_1121/test_app/main/CMakeLists.txt
+++ b/lora/esp_lora_1121/test_app/main/CMakeLists.txt
@@ -1,3 +1,9 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c esp_driver_spi)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
 idf_component_register(SRCS "lr1121_config.c" "test_lr1121.c"
-                       PRIV_REQUIRES spi_flash driver
+                       PRIV_REQUIRES spi_flash ${DRIVER_REQ}
                        INCLUDE_DIRS "")

--- a/sensor/custom_io_expander_ch32v003/CMakeLists.txt
+++ b/sensor/custom_io_expander_ch32v003/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "custom_io_expander_ch32v003.c" INCLUDE_DIRS "include" REQUIRES "driver")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_i2c)
+else()
+    set(REQ driver)
+endif()
+
+idf_component_register(SRCS "custom_io_expander_ch32v003.c" INCLUDE_DIRS "include" REQUIRES ${REQ})

--- a/sensor/custom_io_expander_ch32v003/idf_component.yml
+++ b/sensor/custom_io_expander_ch32v003/idf_component.yml
@@ -9,4 +9,4 @@ repository_info:
   commit_sha: a601dda0fe2effa2a4147414d432273ba48e1d23
   path: sensor/custom_io_expander_ch32v003
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.0.2
+version: 2.0.0

--- a/sensor/custom_io_expander_ch32v003/test_apps/main/CMakeLists.txt
+++ b/sensor/custom_io_expander_ch32v003/test_apps/main/CMakeLists.txt
@@ -1,4 +1,10 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_i2c)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
 idf_component_register(
     SRCS "test_app_ch32v003.c"
-    REQUIRES unity
+    REQUIRES custom_io_expander_ch32v003 ${DRIVER_REQ} unity
     )

--- a/sensor/pcf85063a/CMakeLists.txt
+++ b/sensor/pcf85063a/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "pcf85063a.c"  INCLUDE_DIRS "include" REQUIRES "driver")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_i2c)
+else()
+    set(REQ driver)
+endif()
+
+idf_component_register(SRCS "pcf85063a.c"  INCLUDE_DIRS "include" REQUIRES ${REQ})

--- a/sensor/pcf85063a/README.md
+++ b/sensor/pcf85063a/README.md
@@ -60,7 +60,7 @@ static esp_err_t i2c_master_init(i2c_master_bus_handle_t *bus_handle) {
         pcf85063a_get_time_date(&dev, &Now_time);
 
         // Format current time as a string
-        pcf85063a_datetime_to_str(datetime_str, Now_time);
+        pcf85063a_datetime_to_str(datetime_str, sizeof(datetime_str), Now_time);
         ESP_LOGI(TAG, "Now_time is %s", datetime_str);
 
         // Poll external IO pin for alarm (low level = alarm triggered)

--- a/sensor/pcf85063a/idf_component.yml
+++ b/sensor/pcf85063a/idf_component.yml
@@ -2,5 +2,5 @@ dependencies:
   idf: '>=5.3.2'
 description: "PCF85063A, adapted by the Waveshare team"
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/sensor/pcf85063a"
-version: "1.1.1"
+version: 2.0.0
 

--- a/sensor/pcf85063a/test_app/main/CMakeLists.txt
+++ b/sensor/pcf85063a/test_app/main/CMakeLists.txt
@@ -1,3 +1,9 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_gpio esp_driver_i2c)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
 idf_component_register(SRCS "test_pcf85063a.c"
-                       PRIV_REQUIRES spi_flash driver
+                       PRIV_REQUIRES spi_flash ${DRIVER_REQ}
                        INCLUDE_DIRS "")

--- a/sensor/pcf85063a/test_app/main/test_pcf85063a.c
+++ b/sensor/pcf85063a/test_app/main/test_pcf85063a.c
@@ -96,7 +96,7 @@ static void pcf85063a_test_task(void *arg) {
         pcf85063a_get_time_date(&dev, &Now_time);
 
         // Format current time as a string
-        pcf85063a_datetime_to_str(datetime_str, Now_time);
+        pcf85063a_datetime_to_str(datetime_str, sizeof(datetime_str), Now_time);
         ESP_LOGI(TAG, "Now_time is %s", datetime_str);
 
         // Poll external IO pin for alarm (low level = alarm triggered)

--- a/sensor/qmi8658/CMakeLists.txt
+++ b/sensor/qmi8658/CMakeLists.txt
@@ -1,1 +1,7 @@
-idf_component_register(SRCS "qmi8658.c" INCLUDE_DIRS "include" REQUIRES "driver")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(REQ esp_driver_i2c)
+else()
+    set(REQ driver)
+endif()
+
+idf_component_register(SRCS "qmi8658.c" INCLUDE_DIRS "include" REQUIRES ${REQ})

--- a/sensor/qmi8658/idf_component.yml
+++ b/sensor/qmi8658/idf_component.yml
@@ -2,4 +2,4 @@ dependencies:
   idf: '>=5.3.2'
 description: "QMI8658 sensor, adapted by the Waveshare team"
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/sensor/qmi8658"
-version: "1.0.1"
+version: 2.0.0

--- a/sensor/qmi8658/test_app/main/CMakeLists.txt
+++ b/sensor/qmi8658/test_app/main/CMakeLists.txt
@@ -1,3 +1,9 @@
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.5")
+    set(DRIVER_REQ esp_driver_i2c)
+else()
+    set(DRIVER_REQ driver)
+endif()
+
 idf_component_register(SRCS "test_qmi8658.c"
-                       PRIV_REQUIRES spi_flash driver
+                       PRIV_REQUIRES spi_flash ${DRIVER_REQ}
                        INCLUDE_DIRS "")


### PR DESCRIPTION
## Summary
- add ESP-IDF v6.0 to the component self-check CI matrix
- update ESP32-P4 BSP CMake dependencies for ESP-IDF 5.5+ split driver components and IDF 6 managed usb
- bump ESP32-P4 BSP component versions for the compatibility update

## Validation
- checked staged diff with git diff --cached --check
- verified all ESP32-P4 BSP manifests include the IDF 6 usb dependency and bumped versions