### PR TITLE
Codex/update esp32 s3 lr1121 oled 154

### DIFF
--- a/bsp/esp32_s3_lr1121_oled_1_54/esp32_s3_lr1121_oled_1_54.c
+++ b/bsp/esp32_s3_lr1121_oled_1_54/esp32_s3_lr1121_oled_1_54.c
@@ -30,6 +30,8 @@ static bool spi_initialized = false;
 
 static bq27220_handle_t bq27220 = NULL;
 
+#define BQ27220_CHARGE_CURRENT_MA       0
+
 sdmmc_card_t *bsp_sdcard = NULL; // Global uSD card handler
 temperature_sensor_handle_t temp_sensor = NULL;
 static pcf85063a_dev_t dev;
@@ -60,7 +62,7 @@ static const audio_codec_data_if_t *i2s_data_if = NULL; /* Codec data interface 
 #define BSP_I2S_DUPLEX_MONO_CFG(_sample_rate)                                                         \
     {                                                                                                 \
         .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(_sample_rate),                                          \
-        .slot_cfg = I2S_STD_PHILIP_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO), \
+        .slot_cfg = I2S_STD_PHILIP_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO), \
         .gpio_cfg = BSP_I2S_GPIO_CFG,                                                                 \
     }
 
@@ -84,7 +86,6 @@ esp_err_t bsp_gpio_init(void)
     return ESP_OK;
 }
 
-
 /**************************************************************************************************
  *
  * I2C Function
@@ -96,17 +97,6 @@ esp_err_t bsp_i2c_init(void)
     if (i2c_initialized) {
         return ESP_OK;
     }
-
-    // i2c_master_bus_config_t i2c_bus_conf = {
-    //     .clk_source = I2C_CLK_SRC_DEFAULT,
-    //     .sda_io_num = BSP_I2C_SDA,
-    //     .scl_io_num = BSP_I2C_SCL,
-    //     .i2c_port = BSP_I2C_NUM,
-    //     .glitch_ignore_cnt = 7,
-    //     .flags.enable_internal_pullup = true,
-    //     .trans_queue_depth = 0,
-    // };
-    // BSP_ERROR_CHECK_RETURN_ERR(i2c_new_master_bus(&i2c_bus_conf, &i2c_handle));
 
     i2c_config_t conf = {
         .mode = I2C_MODE_MASTER,
@@ -277,7 +267,7 @@ esp_err_t bsp_audio_poweramp_enable(bool enable)
     return ESP_OK;
 }
 
- esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config, uint32_t sample_rate)
+esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config, uint32_t sample_rate)
 {
     esp_err_t ret = ESP_FAIL;
     if (i2s_tx_chan && i2s_rx_chan)
@@ -306,8 +296,46 @@ esp_err_t bsp_audio_poweramp_enable(bool enable)
     }
     if (i2s_rx_chan != NULL)
     {
-        ESP_GOTO_ON_ERROR(i2s_channel_init_std_mode(i2s_rx_chan, p_i2s_cfg), err, TAG, "I2S channel initialization failed");
-        ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_rx_chan), err, TAG, "I2S enabling failed");
+
+        i2s_tdm_config_t tdm_cfg = {
+            .clk_cfg = {
+                .sample_rate_hz = sample_rate,
+                .clk_src = I2S_CLK_SRC_DEFAULT,
+                .ext_clk_freq_hz = 0,
+                .mclk_multiple = I2S_MCLK_MULTIPLE_256,
+                .bclk_div = 8,
+            },
+            .slot_cfg = {
+                .data_bit_width = I2S_DATA_BIT_WIDTH_16BIT,
+                .slot_bit_width = I2S_SLOT_BIT_WIDTH_AUTO,
+                .slot_mode = I2S_SLOT_MODE_STEREO, //I2S_SLOT_MODE_STEREO
+                .slot_mask = I2S_TDM_SLOT0 | I2S_TDM_SLOT1 | I2S_TDM_SLOT2 | I2S_TDM_SLOT3,
+                .ws_width = I2S_TDM_AUTO_WS_WIDTH,
+                .ws_pol = false,
+                .bit_shift = true,
+                .left_align = false,
+                .big_endian = false,
+                .bit_order_lsb = false,
+                .skip_mask = false,
+                .total_slot = 4
+            },
+            .gpio_cfg = {
+                .mclk = BSP_I2S_MCLK,
+                .bclk = BSP_I2S_SCLK,
+                .ws = BSP_I2S_LCLK,
+                .dout = BSP_I2S_DOUT,
+                .din = BSP_I2S_DSIN,
+                .invert_flags = {
+                    .mclk_inv = false,
+                    .bclk_inv = false,
+                    .ws_inv = false
+                }
+            }
+        };
+        ESP_ERROR_CHECK(i2s_channel_init_tdm_mode(i2s_rx_chan, &tdm_cfg));
+
+        ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_rx_chan), err, TAG, "RX enable failed");
+
     }
 
     audio_codec_i2s_cfg_t i2s_cfg = {
@@ -408,6 +436,7 @@ esp_codec_dev_handle_t bsp_audio_codec_microphone_init(uint32_t sample_rate)
     es7210_codec_cfg_t es7210_cfg = {
         .ctrl_if = i2c_ctrl_if,
     };
+    es7210_cfg.mic_selected = ES7120_SEL_MIC1 | ES7120_SEL_MIC2 | ES7120_SEL_MIC3 | ES7120_SEL_MIC4;
     const audio_codec_if_t *es7210_dev = es7210_codec_new(&es7210_cfg);
     BSP_NULL_CHECK(es7210_dev, NULL);
 
@@ -473,8 +502,9 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
     ESP_ERROR_CHECK(esp_lcd_new_panel_ssd1309(io_handle, &panel_config, &panel_handle));
 
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
-    // ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle,false,true));
     ESP_ERROR_CHECK(esp_lcd_panel_invert_color(panel_handle,false));
+    static const uint8_t blank_buffer[BSP_LCD_H_RES * BSP_LCD_V_RES / 8] = {0};
+    ESP_ERROR_CHECK(esp_lcd_panel_draw_bitmap(panel_handle, 0, 0, BSP_LCD_H_RES, BSP_LCD_V_RES, blank_buffer));
     ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));
 
     if (ret_panel) {
@@ -499,12 +529,12 @@ static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
 
     ESP_LOGI(TAG, "Registering OLED display");
     esp_lv_adapter_display_config_t display_config =  ESP_LV_ADAPTER_DISPLAY_SPI_MONO_DEFAULT_CONFIG(
-        panel_handle,           	// LCD 面板句柄
-        io_handle,        			// LCD 面板 IO 句柄（某些接口可为 NULL）
-        BSP_LCD_H_RES,             		// 水平分辨率
-        BSP_LCD_V_RES,             	// 垂直分辨率
-        cfg->rotation, 	// 旋转角度
-        ESP_LV_ADAPTER_MONO_LAYOUT_VTILED 	// 市场布局
+        panel_handle,           	// LCD panel handle
+        io_handle,        			// LCD panel IO handle (can be NULL)
+        BSP_LCD_H_RES,             		// Horizontal resolution
+        BSP_LCD_V_RES,             	// Vertical resolution
+        cfg->rotation, 	// Rotation
+        ESP_LV_ADAPTER_MONO_LAYOUT_VTILED 	// Vertical tiled layout
     );
     
     return esp_lv_adapter_register_display(&display_config);
@@ -519,17 +549,17 @@ esp_err_t bsp_buttons_new(const bsp_display_cfg_t *cfg, esp_buttons_handle_t *re
             .active_level = 0,
         },
         {
-            .gpio_num = MENU_KEY_GPIO,
+            .gpio_num = PWR_KEY_GPIO,
             .active_level = 0,
         },
         {
-            .gpio_num = PTT_KEY_GPIO,
+            .gpio_num = MENU_KEY_GPIO,
             .active_level = 0,
         },
     };
 
     const button_config_t btn_cfg = {0};
-    /* 创建按键设备 */
+    /* Create button devices */
     esp_err_t ret = iot_button_new_gpio_device(&btn_cfg, &bsp_button_config[0], &prev_btn_handle);
     if (ret != ESP_OK) {
         return ret;
@@ -601,9 +631,9 @@ void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
     lv_disp_set_rotation(disp, rotation);
 }
 
-bool bsp_display_lock(uint32_t timeout_ms)
+bool bsp_display_lock(int32_t timeout_ms)
 {
-    return esp_lv_adapter_lock(timeout_ms);
+    return esp_lv_adapter_lock(timeout_ms) == ESP_OK;
 }
 
 void bsp_display_unlock(void)
@@ -679,16 +709,16 @@ esp_err_t bsp_bat_init(uint16_t mah)
         .full_charge_cap = 650,
         .design_cap = 650,
         .reserve_cap = 0,
-        .near_full = 100,
+        .near_full = 97,
         .self_discharge_rate = 10,
-        .EDV0 = 3200,
-        .EDV1 = 3300,
-        .EDV2 = 3400,
-        .EMF = 3670,
-        .C0 = 115,
-        .R0 = 968,
-        .T0 = 4547,
-        .R1 = 4764,
+        .EDV0 = 3000,
+        .EDV1 = 3150,
+        .EDV2 = 3300,
+        .EMF = 3750,
+        .C0 = 140,
+        .R0 = 1200,
+        .T0 = 4200,
+        .R1 = 5200,
         .TC = 11,
         .C1 = 0,
         .DOD0   = 4200,
@@ -700,8 +730,8 @@ esp_err_t bsp_bat_init(uint16_t mah)
         .DOD60  = 3750,
         .DOD70  = 3700,
         .DOD80  = 3600,
-        .DOD90  = 3450,
-        .DOD100 = 3200,
+        .DOD90  = 3400,
+        .DOD100 = 3000,
     };
     default_cedv.full_charge_cap = mah;
     default_cedv.design_cap = mah;
@@ -729,8 +759,8 @@ esp_err_t bsp_bat_init(uint16_t mah)
 
 esp_err_t bsp_get_bat_info(bsp_bat_info_t *bat_info)
 {
-    bat_info->mv  = bq27220_get_voltage(bq27220);
-    bat_info->ma  = bq27220_get_current(bq27220);
+    bat_info->mv = bq27220_get_voltage(bq27220);
+    bsp_update_bat_charge_status(bat_info);
     bat_info->mah_rem = bq27220_get_remaining_capacity(bq27220);
     bat_info->mah_fcc = bq27220_get_full_charge_capacity(bq27220);
     bat_info->tc = bq27220_get_temperature(bq27220) / 10 - 273; // Convert from 0.1K to Celsius
@@ -744,6 +774,24 @@ esp_err_t bsp_get_bat_info(bsp_bat_info_t *bat_info)
 
     // ESP_LOGI(TAG, "Battery Info - Vol: %dmv, Current: %dmA, Power: %dmW, Remaining Capacity: %dmAh, Full Charge Capacity: %dmAh, Temperature: %dC, Cycle Count: %d, SOC: %d%%, Max Load: %dmA, Time to empty: %dmin, Time to full: %dmin, SOH=%d%%",
     //          bat_info->mv, bat_info->ma, bat_info->mw, bat_info->mah_rem, bat_info->mah_fcc, bat_info->tc, bat_info->cycles, bat_info->soc, bat_info->max_load, bat_info->tte, bat_info->ttf, bat_info->soh);
+
+    return ESP_OK;
+}
+
+esp_err_t bsp_update_bat_charge_status(bsp_bat_info_t *bat_info)
+{
+    ESP_RETURN_ON_FALSE(bat_info && bq27220, ESP_ERR_INVALID_ARG, TAG, "Invalid battery handle");
+
+    int16_t current_ma = bq27220_get_current(bq27220);
+    bat_info->ma = current_ma;
+    bat_info->charging = current_ma >= BQ27220_CHARGE_CURRENT_MA;
+
+    static TickType_t last_log_tick = 0;
+    TickType_t now = xTaskGetTickCount();
+    if (now - last_log_tick >= pdMS_TO_TICKS(1000)) {
+        last_log_tick = now;
+        // ESP_LOGI(TAG, "BQ27220 current: %dmA, charging: %d", current_ma, bat_info->charging);
+    }
 
     return ESP_OK;
 }

--- a/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
+++ b/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
@@ -10,9 +10,6 @@ dependencies:
     public: true
     version: 1.4.*
   idf: '>=5.3'
-  waveshare/esp_lora_1121:
-    public: true
-    version: '*'
   waveshare/esp_oled_ssd1309:
     public: true
     version: ~1.0.2
@@ -29,4 +26,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.0.5
+version: 1.1.0

--- a/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
+++ b/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
@@ -2,31 +2,31 @@ dependencies:
   esp_codec_dev:
     public: true
     version: ~1.3.1
-  espressif/esp_lvgl_adapter: "*"
+  espressif/bq27220:
+    public: true
+    version: '*'
+  espressif/esp_lvgl_adapter: '*'
   espressif/i2c_bus:
     public: true
-    version: 1.4.*  
-  waveshare/esp_oled_ssd1309: 
-    version: "*"
+    version: 1.4.*
+  idf: '>=5.3'
+  waveshare/esp_lora_1121:
     public: true
+    version: '*'
+  waveshare/esp_oled_ssd1309:
+    public: true
+    version: ~1.0.2
   waveshare/pcf85063a:
     public: true
     version: '*'
-  waveshare/esp_lora_1121:
-    public: true
-    version: '*'  
-  espressif/bq27220:
-    public: true
-    version: '*'  
-  idf: '>=5.3'
 description: Board Support Package (BSP) for Waveshare ESP32-S3-LR1121-OLED-1.54
 repository: git://github.com/waveshareteam/Waveshare-ESP32-components.git
 repository_info:
-  commit_sha: c878e3e56f23f7cdd67ac36e13ec549705f0a5d4
+  commit_sha: 6318c4d765af1a2e92e682e7db4b498da793fc43
   path: bsp/esp32_s3_lr1121_oled_1_54
 tags:
 - bsp
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.0.2
+version: 1.0.5

--- a/bsp/esp32_s3_lr1121_oled_1_54/include/bsp/esp32_s3_lr1121_oled_1_54.h
+++ b/bsp/esp32_s3_lr1121_oled_1_54/include/bsp/esp32_s3_lr1121_oled_1_54.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <stdint.h>
+
 #include "sdkconfig.h"
 #include "driver/gpio.h"
 #include "driver/spi_master.h"    
 #include "i2c_bus.h"
 #include "driver/sdmmc_host.h"
 #include "driver/i2s_std.h"
+#include "driver/i2s_tdm.h"
 #include "esp_oled_ssd1309.h"
 #include "driver/temperature_sensor.h"
 #include "pcf85063a.h"
@@ -88,6 +91,7 @@
 
 #define PTT_KEY_GPIO GPIO_NUM_6
 #define MENU_KEY_GPIO GPIO_NUM_5
+#define PWR_KEY_GPIO GPIO_NUM_4
 #define BOOT_KEY_GPIO GPIO_NUM_0
 #define BUTTON_ACTIVE_LEVEL   0
 
@@ -354,11 +358,11 @@ lv_indev_t *bsp_display_get_input_dev(void);
 /**
  * @brief Take LVGL mutex
  *
- * @param timeout_ms Timeout in [ms]. 0 will block indefinitely.
+ * @param timeout_ms Timeout in [ms]. -1 will block indefinitely.
  * @return true  Mutex was taken
  * @return false Mutex was NOT taken
  */
-bool bsp_display_lock(uint32_t timeout_ms);
+bool bsp_display_lock(int32_t timeout_ms);
 
 /**
  * @brief Give LVGL mutex
@@ -495,10 +499,12 @@ typedef struct {
     uint16_t cycles;    // 循环次数（cycle count）
     uint16_t soh;       // 健康度（State of Health %）
     uint16_t tc;        // 温度（°C）
+    bool charging;      // 电池当前是否有充电电流
 } bsp_bat_info_t;
 
 esp_err_t bsp_bat_init(uint16_t mah);
 esp_err_t bsp_get_bat_info(bsp_bat_info_t *bat_info);
+esp_err_t bsp_update_bat_charge_status(bsp_bat_info_t *bat_info);
 
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 

--- a/sensor/custom_io_expander_ch32v003/custom_io_expander_ch32v003.c
+++ b/sensor/custom_io_expander_ch32v003/custom_io_expander_ch32v003.c
@@ -17,7 +17,7 @@
 #define I2C_TIMEOUT_MS          (1000)
 #define I2C_CLK_SPEED           (400000)
 
-#define IO_COUNT                (8)
+#define IO_COUNT                (16)
 
 /* Register address */
 #define DIRECTION_REG_ADDR      (0x02)
@@ -28,8 +28,8 @@
 #define RTC_REG_ADDR            (0x07)
 
 /* Default register value on power-up */
-#define DIR_REG_DEFAULT_VAL     (0xff)
-#define OUT_REG_DEFAULT_VAL     (0x00)
+#define DIR_REG_DEFAULT_VAL     (0xffff)
+#define OUT_REG_DEFAULT_VAL     (0x0000)
 
 /**
  * @brief Device Structure Type
@@ -39,8 +39,8 @@ typedef struct {
     esp_io_expander_t base;
     i2c_master_dev_handle_t i2c_handle;
     struct {
-        uint8_t direction;
-        uint8_t output;
+        uint16_t direction;
+        uint16_t output;
     } regs;
 } custom_io_expander_ch32v003_t;
 
@@ -96,20 +96,20 @@ static esp_err_t read_input_reg(esp_io_expander_handle_t handle, uint32_t *value
 {
     custom_io_expander_ch32v003_t *custom_io = (custom_io_expander_ch32v003_t *)__containerof(handle, custom_io_expander_ch32v003_t, base);
 
-    uint8_t temp = 0;
+    uint8_t temp[2] = {0};
     ESP_RETURN_ON_ERROR(i2c_master_transmit_receive(custom_io->i2c_handle, (uint8_t[]) {
         INPUT_REG_ADDR
-    }, 1, &temp, sizeof(temp), I2C_TIMEOUT_MS), TAG, "Read input reg failed");
-    *value = temp;
+    }, 1, temp, sizeof(temp), I2C_TIMEOUT_MS), TAG, "Read input reg failed");
+    *value = (((uint32_t)temp[1]) << 8) | (temp[0]);
     return ESP_OK;
 }
 
 static esp_err_t write_output_reg(esp_io_expander_handle_t handle, uint32_t value)
 {
     custom_io_expander_ch32v003_t *custom_io = (custom_io_expander_ch32v003_t *)__containerof(handle, custom_io_expander_ch32v003_t, base);
-    value &= 0xff;
+    value &= 0xffff;
 
-    uint8_t data[] = {OUTPUT_REG_ADDR, value};
+    uint8_t data[] = {OUTPUT_REG_ADDR, value & 0xff, value >> 8};
     ESP_RETURN_ON_ERROR(i2c_master_transmit(custom_io->i2c_handle, data, sizeof(data), I2C_TIMEOUT_MS), TAG, "Write output reg failed");
     custom_io->regs.output = value;
     return ESP_OK;
@@ -126,9 +126,9 @@ static esp_err_t read_output_reg(esp_io_expander_handle_t handle, uint32_t *valu
 static esp_err_t write_direction_reg(esp_io_expander_handle_t handle, uint32_t value)
 {
     custom_io_expander_ch32v003_t *custom_io = (custom_io_expander_ch32v003_t *)__containerof(handle, custom_io_expander_ch32v003_t, base);
-    value &= 0xff;
+    value &= 0xffff;
 
-    uint8_t data[] = {DIRECTION_REG_ADDR, value};
+    uint8_t data[] = {DIRECTION_REG_ADDR, value & 0xff, value >> 8};
     ESP_RETURN_ON_ERROR(i2c_master_transmit(custom_io->i2c_handle, data, sizeof(data), I2C_TIMEOUT_MS), TAG, "Write direction reg failed");
     custom_io->regs.direction = value;
     return ESP_OK;

--- a/sensor/custom_io_expander_ch32v003/idf_component.yml
+++ b/sensor/custom_io_expander_ch32v003/idf_component.yml
@@ -9,4 +9,4 @@ repository_info:
   commit_sha: a601dda0fe2effa2a4147414d432273ba48e1d23
   path: custom_io/custom_io_expander_ch32v003
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 1.0.1
+version: 1.1.1

--- a/sensor/custom_io_expander_ch32v003/include/custom_io_expander_ch32v003.h
+++ b/sensor/custom_io_expander_ch32v003/include/custom_io_expander_ch32v003.h
@@ -1,12 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2026 Waveshare Electronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /**
  * @file
- * @brief ESP IO expander: TCA9554
+ * @brief ESP IO expander: CH32V003
  */
 
 #pragma once


### PR DESCRIPTION
## Summary
- Update ESP32-S3-LR1121-OLED-1.54 BSP audio initialization for mono TX and TDM RX
- Add ES7210 microphone channel selection and battery charging status reporting
- Fix display init cleanup, button GPIO mapping, LVGL lock return handling, and component dependencies/version

## Testing
- Ran `git diff --cached --check`
- ESP-IDF build was not completed because the local ESP-IDF Python environment is missing:
  `F:\Espressif\python_env\idf6.2_py3.11_env\Scripts\python.exe`