### PR TITLE
Update ESP32-S3 LR1121 OLED BSP

### DIFF
--- a/bsp/esp32_s3_lr1121_oled_1_54/esp32_s3_lr1121_oled_1_54.c
+++ b/bsp/esp32_s3_lr1121_oled_1_54/esp32_s3_lr1121_oled_1_54.c
@@ -501,6 +501,8 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
 
     ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_invert_color(panel_handle,false));
+    static const uint8_t blank_buffer[BSP_LCD_H_RES * BSP_LCD_V_RES / 8] = {0};
+    ESP_ERROR_CHECK(esp_lcd_panel_draw_bitmap(panel_handle, 0, 0, BSP_LCD_H_RES, BSP_LCD_V_RES, blank_buffer));
     ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));
 
     if (ret_panel) {
@@ -635,9 +637,9 @@ void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
     lv_disp_set_rotation(disp, rotation);
 }
 
-bool bsp_display_lock(uint32_t timeout_ms)
+bool bsp_display_lock(int32_t timeout_ms)
 {
-    return esp_lv_adapter_lock(timeout_ms);
+    return esp_lv_adapter_lock(timeout_ms) == ESP_OK;
 }
 
 void bsp_display_unlock(void)
@@ -713,29 +715,29 @@ esp_err_t bsp_bat_init(uint16_t mah)
         .full_charge_cap = 650,
         .design_cap = 650,
         .reserve_cap = 0,
-        .near_full = 97,
-        .self_discharge_rate = 10,
-        .EDV0 = 3000,
-        .EDV1 = 3150,
-        .EDV2 = 3300,
-        .EMF = 3750,
-        .C0 = 140,
-        .R0 = 1200,
-        .T0 = 4200,
-        .R1 = 5200,
+        .near_full = 200,
+        .self_discharge_rate = 20,
+        .EDV0 = 3490,
+        .EDV1 = 3511,
+        .EDV2 = 3535,
+        .EMF = 3670,
+        .C0 = 115,
+        .R0 = 968,
+        .T0 = 4547,
+        .R1 = 4764,
         .TC = 11,
         .C1 = 0,
-        .DOD0   = 4200,
-        .DOD10  = 4100,
-        .DOD20  = 4000,
-        .DOD30  = 3920,
-        .DOD40  = 3850,
-        .DOD50  = 3800,
-        .DOD60  = 3750,
-        .DOD70  = 3700,
-        .DOD80  = 3600,
-        .DOD90  = 3400,
-        .DOD100 = 3000,
+        .DOD0 = 4147,
+        .DOD10 = 4002,
+        .DOD20 = 3969,
+        .DOD30 = 3938,
+        .DOD40 = 3880,
+        .DOD50 = 3824,
+        .DOD60 = 3794,
+        .DOD70 = 3753,
+        .DOD80 = 3677,
+        .DOD90 = 3574,
+        .DOD100 = 3490,
     };
     default_cedv.full_charge_cap = mah;
     default_cedv.design_cap = mah;
@@ -764,7 +766,7 @@ esp_err_t bsp_bat_init(uint16_t mah)
 esp_err_t bsp_get_bat_info(bsp_bat_info_t *bat_info)
 {
     bat_info->mv  = bq27220_get_voltage(bq27220);
-    bat_info->ma  = bq27220_get_current(bq27220);
+    BSP_ERROR_CHECK_RETURN_ERR(bsp_update_bat_charge_status(bat_info));
     bat_info->mah_rem = bq27220_get_remaining_capacity(bq27220);
     bat_info->mah_fcc = bq27220_get_full_charge_capacity(bq27220);
     bat_info->tc = bq27220_get_temperature(bq27220) / 10 - 273; // Convert from 0.1K to Celsius
@@ -781,6 +783,25 @@ esp_err_t bsp_get_bat_info(bsp_bat_info_t *bat_info)
 
     return ESP_OK;
 }
+
+esp_err_t bsp_update_bat_charge_status(bsp_bat_info_t *bat_info)
+{
+    ESP_RETURN_ON_FALSE(bat_info && bq27220, ESP_ERR_INVALID_ARG, TAG, "Invalid battery handle");
+
+    int16_t current_ma = bq27220_get_current(bq27220);
+    bat_info->ma = current_ma;
+    bat_info->charging = current_ma >= BQ27220_CHARGE_CURRENT_MA;
+
+    static TickType_t last_log_tick = 0;
+    TickType_t now = xTaskGetTickCount();
+    if (now - last_log_tick >= pdMS_TO_TICKS(1000)) {
+        last_log_tick = now;
+        // ESP_LOGI(TAG, "BQ27220 current: %dmA, charging: %d", current_ma, bat_info->charging);
+    }
+
+    return ESP_OK;
+}
+
  /**************************************************************************************************
  *
  * Other Function

--- a/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
+++ b/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
@@ -5,19 +5,16 @@ dependencies:
   espressif/esp_lvgl_adapter: "*"
   espressif/i2c_bus:
     public: true
-    version: 1.4.*  
-  waveshare/esp_oled_ssd1309: 
+    version: 1.4.*
+  waveshare/esp_oled_ssd1309:
     version: ~1.0.2
     public: true
   waveshare/pcf85063a:
     public: true
     version: '*'
-  waveshare/esp_lora_1121:
-    public: true
-    version: '*'  
   espressif/bq27220:
     public: true
-    version: '*'  
+    version: '*'
   idf: '>=5.3'
 description: Board Support Package (BSP) for Waveshare ESP32-S3-LR1121-OLED-1.54
 repository: git://github.com/waveshareteam/Waveshare-ESP32-components.git
@@ -29,4 +26,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 2.0.0
+version: 2.0.1

--- a/bsp/esp32_s3_lr1121_oled_1_54/include/bsp/esp32_s3_lr1121_oled_1_54.h
+++ b/bsp/esp32_s3_lr1121_oled_1_54/include/bsp/esp32_s3_lr1121_oled_1_54.h
@@ -98,6 +98,8 @@
 
 #define LVGL_BUFFER_HEIGHT      (CONFIG_BSP_DISPLAY_LVGL_BUF_HEIGHT)
 
+#define BQ27220_CHARGE_CURRENT_MA       0
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -360,7 +362,7 @@ lv_indev_t *bsp_display_get_input_dev(void);
  * @return true  Mutex was taken
  * @return false Mutex was NOT taken
  */
-bool bsp_display_lock(uint32_t timeout_ms);
+bool bsp_display_lock(int32_t timeout_ms);
 
 /**
  * @brief Give LVGL mutex
@@ -497,10 +499,12 @@ typedef struct {
     uint16_t cycles;    // 循环次数（cycle count）
     uint16_t soh;       // 健康度（State of Health %）
     uint16_t tc;        // 温度（°C）
+    bool charging;      // 电池当前是否有充电电流
 } bsp_bat_info_t;
 
 esp_err_t bsp_bat_init(uint16_t mah);
 esp_err_t bsp_get_bat_info(bsp_bat_info_t *bat_info);
+esp_err_t bsp_update_bat_charge_status(bsp_bat_info_t *bat_info);
 
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 


### PR DESCRIPTION
## Summary
- Clear the SSD1309 OLED framebuffer during display initialization to avoid stale pixels after panel startup.
- Update LVGL display lock API handling to accept `-1` as the indefinite timeout and return a boolean based on `esp_lv_adapter_lock()` result.
- Retune BQ27220 CEDV battery profile values for the board battery configuration.
- Add battery charging status reporting through `bsp_bat_info_t::charging` and `bsp_update_bat_charge_status()`.
- Remove the unused `waveshare/esp_lora_1121` component dependency from this BSP manifest.
- Bump `esp32_s3_lr1121_oled_1_54` component version from `2.0.0` to `2.0.1`.

## Notes
- Kept `pcf85063a_datetime_to_str()` using the current 3-argument signature from `sensor/pcf85063a`.
- `bsp_get_bat_info()` now fills both `ma` and `charging` via `bsp_update_bat_charge_status()`.

## Testing
- Passed `git diff --cached --check`
- Passed manifest self-check:
  - Changed component: `bsp/esp32_s3_lr1121_oled_1_54`
  - Version bump: `2.0.0 -> 2.0.1`
- Build check attempted with `.github/scripts/build_changed_component.py`, but local ESP-IDF Python environment is not active:
  - `No module named 'rich_click'`