### PR TITLE
Add esp32 c5 lcd 1.47

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -56,6 +56,7 @@ jobs:
             lora/esp_lora_1121;
             bsp/esp32_s3_lr1121_oled_1_54;
             display/oled/esp_oled_ssd1309;
+            bsp/esp32_c5_lcd_1_47;
             
           namespace: "waveshare"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/bsp/esp32_c5_lcd_1_47/CMakeLists.txt
+++ b/bsp/esp32_c5_lcd_1_47/CMakeLists.txt
@@ -1,0 +1,23 @@
+file(GLOB_RECURSE SRCS *.c)
+
+idf_component_register(
+    SRCS ${SRCS}
+    INCLUDE_DIRS "include"
+    PRIV_INCLUDE_DIRS "priv_include"
+    REQUIRES
+        esp_driver_gpio
+        esp_driver_i2c
+        esp_lcd
+        espressif__esp_lvgl_port
+        espressif__led_strip
+        lvgl__lvgl
+        sdmmc
+    PRIV_REQUIRES
+        esp_driver_ledc
+        esp_driver_sdspi
+        esp_driver_spi
+        esp_psram
+        esp_timer
+        fatfs
+        spiffs
+)

--- a/bsp/esp32_c5_lcd_1_47/Kconfig
+++ b/bsp/esp32_c5_lcd_1_47/Kconfig
@@ -1,0 +1,93 @@
+menu "Board Support Package"
+
+    config BSP_ERROR_CHECK
+        bool "Enable error check in BSP"
+        default y
+        help
+            Error check assert the application before returning the error code.
+
+    menu "I2C"
+        config BSP_I2C_NUM
+            int "I2C peripheral index"
+            default 1
+            range 0 1
+            help
+                ESP32S3 has two I2C peripherals, pick the one you want to use.
+
+        config BSP_I2C_FAST_MODE
+            bool "Enable I2C fast mode"
+            default y
+            help
+                I2C has two speed modes: normal (100kHz) and fast (400kHz).
+
+        config BSP_I2C_CLK_SPEED_HZ
+            int
+            default 400000 if BSP_I2C_FAST_MODE
+            default 100000
+    endmenu
+
+    menu "SPIFFS - Virtual File System"
+        config BSP_SPIFFS_FORMAT_ON_MOUNT_FAIL
+            bool "Format SPIFFS if mounting fails"
+            default n
+            help
+                Format SPIFFS if it fails to mount the filesystem.
+
+        config BSP_SPIFFS_MOUNT_POINT
+            string "SPIFFS mount point"
+            default "/spiffs"
+            help
+                Mount point of SPIFFS in the Virtual File System.
+
+        config BSP_SPIFFS_PARTITION_LABEL
+            string "Partition label of SPIFFS"
+            default "storage"
+            help
+                Partition label which stores SPIFFS.
+
+        config BSP_SPIFFS_MAX_FILES
+            int "Max files supported for SPIFFS VFS"
+            default 5
+            help
+                Supported max files for SPIFFS in the Virtual File System.
+    endmenu
+
+    menu "uSD card - Virtual File System"
+        config BSP_SD_FORMAT_ON_MOUNT_FAIL
+            bool "Format uSD card if mounting fails"
+            default n
+            help
+                The SDMMC host will format (FAT) the uSD card if it fails to mount the filesystem.
+
+        config BSP_SD_MOUNT_POINT
+            string "uSD card mount point"
+            default "/sdcard"
+            help
+                Mount point of the uSD card in the Virtual File System
+
+    endmenu
+
+    menu "Display"
+        config BSP_LCD_RGB_BOUNCE_BUFFER_HEIGHT
+            int "RGB Bounce buffer height"
+            default 20
+            help
+                Height of bounce buffer. The width of the buffer is the same as that of the LCD.
+
+        config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
+            int "LEDC channel index"
+            default 1
+            range 0 7
+            help
+                LEDC channel is used to generate PWM signal that controls display brightness.
+                Set LEDC index that should be used.
+
+        config BSP_DISPLAY_LVGL_BUF_HEIGHT
+            depends on !BSP_DISPLAY_LVGL_AVOID_TEAR
+            int "LVGL buffer height"
+            default 100
+            help
+                Height of LVGL buffer. The width of the buffer is the same as that of the LCD.
+    endmenu
+
+endmenu

--- a/bsp/esp32_c5_lcd_1_47/Kconfig
+++ b/bsp/esp32_c5_lcd_1_47/Kconfig
@@ -12,7 +12,7 @@ menu "Board Support Package"
             default 1
             range 0 1
             help
-                ESP32S3 has two I2C peripherals, pick the one you want to use.
+                Select the I2C peripheral used by the BSP I2C helper APIs.
 
         config BSP_I2C_FAST_MODE
             bool "Enable I2C fast mode"
@@ -57,7 +57,7 @@ menu "Board Support Package"
             bool "Format uSD card if mounting fails"
             default n
             help
-                The SDMMC host will format (FAT) the uSD card if it fails to mount the filesystem.
+                Format the microSD card with FAT if mounting fails.
 
         config BSP_SD_MOUNT_POINT
             string "uSD card mount point"
@@ -69,10 +69,10 @@ menu "Board Support Package"
 
     menu "Display"
         config BSP_LCD_RGB_BOUNCE_BUFFER_HEIGHT
-            int "RGB Bounce buffer height"
+            int "LCD draw buffer height"
             default 20
             help
-                Height of bounce buffer. The width of the buffer is the same as that of the LCD.
+                Height of the LCD draw buffer. The width of the buffer is the same as the LCD width.
 
         config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
             int "LEDC channel index"
@@ -80,7 +80,7 @@ menu "Board Support Package"
             range 0 7
             help
                 LEDC channel is used to generate PWM signal that controls display brightness.
-                Set LEDC index that should be used.
+                Select the LEDC channel used for the LCD backlight PWM signal.
 
         config BSP_DISPLAY_LVGL_BUF_HEIGHT
             depends on !BSP_DISPLAY_LVGL_AVOID_TEAR

--- a/bsp/esp32_c5_lcd_1_47/LICENSE
+++ b/bsp/esp32_c5_lcd_1_47/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/bsp/esp32_c5_lcd_1_47/README.md
+++ b/bsp/esp32_c5_lcd_1_47/README.md
@@ -1,125 +1,92 @@
-# BSP: ESP32-S3-LCD-EV-Board
+# BSP: ESP32-C5-LCD-1.47
 
-| [HW Reference](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-lcd-ev-board/user_guide.html) | [HOW TO USE API](#api-reference) | [EXAMPLES](#compatible-bsp-examples) | [![Component Registry](https://components.espressif.com/components/espressif/esp32_s3_lcd_ev_board/badge.svg)](https://components.espressif.com/components/espressif/esp32_s3_lcd_ev_board) | ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg) |
-| --- | --- | --- | --- | -- |
+[![Component Registry](https://components.espressif.com/components/waveshare/esp32_c5_lcd_1_47/badge.svg)](https://components.espressif.com/components/waveshare/esp32_c5_lcd_1_47)
+![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 ## Overview
 
-<table>
-<tr><td>
+ESP32-C5-LCD-1.47 is a Waveshare ESP32-C5 board with a 1.47-inch SPI LCD. This BSP provides board-level initialization helpers for the display, storage, LVGL, and onboard WS2812 LED.
 
-ESP32-S3-LCD-EV-Board is a development board for evaluating and verifying ESP32-S3 screen interactive applications. It has the functions of touch screen interaction and voice interaction. The development board has the following characteristics:
+Main features:
 
-* Onboard ESP32-S3-WROOM-1 module, with built-in 16 MB Flash + 8/16 MB PSRAM
-* Onboard audio codec + audio amplifier
-* Onboard dual microphone pickup
-* USB type-C interface download and debugging
-* It can be used with different screen sub boards, and supports `RGB`, `8080`, `SPI`, `I2C` interface screens, as below:
+- ESP32-C5 target support
+- 1.47-inch ST7789 SPI LCD, 172 x 320, RGB565
+- LVGL port integration with configurable draw buffer height
+- PWM LCD backlight brightness control
+- SPIFFS virtual filesystem helpers
+- SDSPI microSD card mount and unmount helpers
+- Onboard WS2812 LED strip helper APIs
 
-</td><td width="200">
-  <img src="doc/esp32_s3_lcd_ev_board.webp">
-  <img src="doc/esp32_s3_lcd_ev_board_2.webp">
-</td></tr>
-</table>
+## Pin Assignment
 
+| Function | GPIO |
+| --- | --- |
+| LCD CS | GPIO23 |
+| LCD CLK | GPIO7 |
+| LCD MOSI | GPIO6 |
+| LCD DC | GPIO24 |
+| LCD RST | GPIO26 |
+| LCD Backlight | GPIO10 |
+| microSD D0/MISO | GPIO5 |
+| microSD CMD/MOSI | GPIO6 |
+| microSD CLK | GPIO7 |
+| microSD CS | GPIO4 |
+| WS2812 data | GPIO8 |
 
-|         Board Name         | Screen Size (inch) | Resolution | LCD Driver IC (Interface) | Touch Driver IC |                                                                            Schematic                                                                            | Support |
-| -------------------------- | ------------------ | ---------- | ------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| ESP32-S3-LCD-EV-Board-SUB1 | 0.9                | 128 x 64   | SSD1315 (I2C)             | *               | [link](https://docs.espressif.com/projects/esp-dev-kits/zh_CN/latest/_static/esp32-s3-lcd-ev-board/schematics/SCH_ESP32-S3-LCD-Ev-Board-SUB1_V1.0_20220617.pdf) | Not yet |
-|                            | 2.4                | 320 x 240  | ST7789V (SPI)             | XTP2046         |                                                                                                                                                                 | Not yet |
-| ESP32-S3-LCD-EV-Board-SUB2 | 3.5                | 480 x 320  | ST7796S (8080)            | GT911           | [link](https://docs.espressif.com/projects/esp-dev-kits/zh_CN/latest/_static/esp32-s3-lcd-ev-board/schematics/SCH_ESP32-S3-LCD-EV-Board-SUB2_V1.2_20230509.pdf) | Not yet |
-|                            | 3.95               | 480 x 480  | GC9503CV (RGB)            | FT5x06          |                                                                                                                                                                 | Yes     |
-| ESP32-S3-LCD-EV-Board-SUB3 | 4.3                | 800 x 480  | ST7262E43 (RGB)           | GT1151          | [link](https://docs.espressif.com/projects/esp-dev-kits/zh_CN/latest/_static/esp32-s3-lcd-ev-board/schematics/SCH_ESP32-S3-LCD-EV-Board-SUB3_V1.1_20230315.pdf) | Yes     |
+## Capabilities and Dependencies
 
-Here are some useful configurations in menuconfig that can be customed by user:
+| Available | Capability | Component | Version |
+| --- | --- | --- | --- |
+| Yes | Display | IDF `esp_lcd` | `>=5.3` |
+| Yes | LVGL port | `espressif/esp_lvgl_port` | `^2` |
+| Yes | LVGL | `lvgl/lvgl` | `>=8,<10` |
+| Yes | WS2812 LED | `espressif/led_strip` | `*` |
+| Yes | SPIFFS | IDF `spiffs` | `>=5.3` |
+| Yes | microSD card | IDF `sdmmc`, `fatfs` | `>=5.3` |
+| No | Touch | - | - |
+| No | Buttons | - | - |
+| No | Audio | - | - |
+| No | IMU | - | - |
 
-* `BSP_LCD_RGB_BUFFER_NUMS`: Configure the number of frame buffers. The anti-tearing function can be activated only when set to a value greater than one.
-* `BSP_LCD_RGB_REFRESH_MODE`: Choose the refresh mode for the RGB LCD.
-    * `BSP_LCD_RGB_REFRESH_AUTO`: Use the most common method to refresh the LCD.
-    * `BSP_LCD_RGB_BOUNCE_BUFFER_MODE`: Enabling bounce buffer mode can lead to a higher PCLK frequency at the expense of increased CPU consumption. **This mode is particularly useful when dealing with [screen drift](https://docs.espressif.com/projects/esp-faq/en/latest/software-framework/peripherals/lcd.html#why-do-i-get-drift-overall-drift-of-the-display-when-esp32-s3-is-driving-an-rgb-lcd-screen), especially in scenarios involving Wi-Fi usage or writing to Flash memory.** This feature should be used in conjunction with `ESP32S3_DATA_CACHE_LINE_64B` configuration. For more detailed information, refer to the [documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/lcd.html#bounce-buffer-with-single-psram-frame-buffer).
-* `BSP_DISPLAY_LVGL_BUF_CAPS`: Select the memory type for the LVGL buffer. Internal memory offers better performance.
-* `BSP_DISPLAY_LVGL_BUF_HEIGHT`: Set the height of the LVGL buffer, with its width aligning with the LCD's width. The default value is 100, decreasing it can lower memory consumption.
-* `BSP_DISPLAY_LVGL_AVOID_TEAR`: Avoid tearing effect by using multiple buffers. This requires setting `BSP_LCD_RGB_BUFFER_NUMS` to a value greater than 1.
-    * `BSP_DISPLAY_LVGL_MODE`:
-        * `BSP_DISPLAY_LVGL_FULL_REFRESH`: Use LVGL full-refresh mode. Set `BSP_LCD_RGB_BUFFER_NUMS` to `3` will get higher FPS`.
-        * `BSP_DISPLAY_LVGL_DIRECT_MODE`: Use LVGL's direct mode.
+## Configuration
 
-Based on the above configurations, there are three different anti-tearing modes can be used:
+The following options are available in `menuconfig` under `Board Support Package`:
 
-* RGB double-buffer + LVGL full-refresh mode:
-    * Set `BSP_LCD_RGB_BUFFER_NUMS` to `2`
-    * Enable `BSP_DISPLAY_LVGL_AVOID_TEAR` and `BSP_DISPLAY_LVGL_FULL_REFRESH`
-* RGB double-buffer + LVGL direct-mode:
-    * Set `BSP_LCD_RGB_BUFFER_NUMS` to `2`
-    * Enable `BSP_DISPLAY_LVGL_AVOID_TEAR` and `BSP_DISPLAY_LVGL_DIRECT_MODE`
-* RGB triple-buffer + LVGL full-refresh mode:
-    * Set `BSP_LCD_RGB_BUFFER_NUMS` to `3`
-    * Enable `BSP_DISPLAY_LVGL_AVOID_TEAR` and `BSP_DISPLAY_LVGL_FULL_REFRESH`
+- `BSP_ERROR_CHECK`: Enable assert-style error checking in BSP helpers.
+- `BSP_I2C_NUM`: Select the I2C peripheral used by BSP I2C helpers.
+- `BSP_I2C_FAST_MODE`: Select 400 kHz I2C mode instead of 100 kHz mode.
+- `BSP_SPIFFS_*`: Configure SPIFFS mount behavior, partition label, mount point, and max open files.
+- `BSP_SD_*`: Configure microSD card mount point and format-on-failure behavior.
+- `BSP_LCD_RGB_BOUNCE_BUFFER_HEIGHT`: Configure the display draw buffer height used by the BSP.
+- `BSP_DISPLAY_BRIGHTNESS_LEDC_CH`: Select the LEDC channel used for LCD backlight PWM.
+- `BSP_DISPLAY_LVGL_BUF_HEIGHT`: Configure the LVGL draw buffer height.
 
-## Capabilities and dependencies
+## Basic Usage
 
-<div align="center">
-<!-- START_DEPENDENCIES -->
+```c
+#include "bsp/esp-bsp.h"
 
-|     Available    |       Capability       |Controller/Codec|                                                                                                              Component                                                                                                              |      Version      |
-|------------------|------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
-|:heavy_check_mark:|     :pager: DISPLAY    |                |[espressif/esp_lcd_gc9503](https://components.espressif.com/components/espressif/esp_lcd_gc9503)<br/>[espressif/esp_lcd_panel_io_additions](https://components.espressif.com/components/espressif/esp_lcd_panel_io_additions)<br/>idf|^3<br/>^1<br/>>=5.3|
-|:heavy_check_mark:|:black_circle: LVGL_PORT|                |                                                                    [espressif/esp_lvgl_port](https://components.espressif.com/components/espressif/esp_lvgl_port)                                                                   |         ^2        |
-|:heavy_check_mark:|    :point_up: TOUCH    |                |    [espressif/esp_lcd_touch_ft5x06](https://components.espressif.com/components/espressif/esp_lcd_touch_ft5x06)<br/>[espressif/esp_lcd_touch_gt1151](https://components.espressif.com/components/espressif/esp_lcd_touch_gt1151)    |     ^1<br/>^1     |
-|:heavy_check_mark:| :radio_button: BUTTONS |                |                                                                           [espressif/button](https://components.espressif.com/components/espressif/button)                                                                          |         ^4        |
-|:heavy_check_mark:|  :musical_note: AUDIO  |                |                                                                    [espressif/esp_codec_dev](https://components.espressif.com/components/espressif/esp_codec_dev)                                                                   |       ~1.3.1      |
-|:heavy_check_mark:| :speaker: AUDIO_SPEAKER|     es8311     |                                                                                                                                                                                                                                     |                   |
-|:heavy_check_mark:| :microphone: AUDIO_MIC |     es7210     |                                                                                                                                                                                                                                     |                   |
-|        :x:       |  :floppy_disk: SDCARD  |                |                                                                                                                                                                                                                                     |                   |
-|        :x:       |    :video_game: IMU    |                |                                                                                                                                                                                                                                     |                   |
+void app_main(void)
+{
+    lv_display_t *display = bsp_display_start();
+    if (display) {
+        bsp_display_backlight_on();
+        bsp_display_brightness_set(80);
+    }
 
-<!-- END_DEPENDENCIES -->
-</div>
+    bsp_ws2812b_init();
+    bsp_setledcolor(0, 255, 0, 0);
+}
+```
 
-## Compatible BSP Examples
+## Storage Usage
 
-<div align="center">
-<!-- START_EXAMPLES -->
+```c
+#include "bsp/esp-bsp.h"
 
-| Example | Description | Try with ESP Launchpad |
-| ------- | ----------- | ---------------------- |
-| [Display Example](https://github.com/espressif/esp-bsp/tree/master/examples/display) | Show an image on the screen with a simple startup animation (LVGL) | [Flash Example](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display) |
-| [Display, Audio and Photo Example](https://github.com/espressif/esp-bsp/tree/master/examples/display_audio_photo) | Complex demo: browse files from filesystem and play/display JPEG, WAV, or TXT files (LVGL) | [Flash Example](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_audio_photo) |
-| [LVGL Benchmark Example](https://github.com/espressif/esp-bsp/tree/master/examples/display_lvgl_benchmark) | Run LVGL benchmark tests | - |
-| [LVGL Demos Example](https://github.com/espressif/esp-bsp/tree/master/examples/display_lvgl_demos) | Run the LVGL demo player - all LVGL examples are included (LVGL) | [Flash Example](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_lvgl_demo) |
-| [Display Rotation Example](https://github.com/espressif/esp-bsp/tree/master/examples/display_rotation) | Rotate screen using buttons or an accelerometer (`BSP_CAPS_IMU`, if available) | [Flash Example](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_rotation) |
-
-<!-- END_EXAMPLES -->
-</div>
-
-<!-- START_BENCHMARK -->
-
-## LVGL Benchmark
-
-**DATE:** 08.07.2025 10:31
-
-**LVGL version:** 9.3.0
-
-| Name | Avg. CPU | Avg. FPS | Avg. time | render time | flush time |
-| ---- | :------: | :------: | :-------: | :---------: | :--------: |
-| Empty screen | 98%  | 18  | 51  | 30  | 21  |
-| Moving wallpaper | 100%  | 8  | 109  | 84  | 25  |
-| Single rectangle | 99%  | 35  | 24  | 1  | 23  |
-| Multiple rectangles | 99%  | 32  | 27  | 18  | 9  |
-| Multiple RGB images | 99%  | 28  | 29  | 22  | 7  |
-| Multiple ARGB images | 99%  | 16  | 51  | 36  | 15  |
-| Rotated ARGB images | 100%  | 15  | 59  | 51  | 8  |
-| Multiple labels | 99%  | 18  | 47  | 35  | 12  |
-| Screen sized text | 100%  | 8  | 110  | 91  | 19  |
-| Multiple arcs | 99%  | 35  | 23  | 8  | 15  |
-| Containers | 99%  | 14  | 56  | 41  | 15  |
-| Containers with overlay | 99%  | 9  | 87  | 75  | 12  |
-| Containers with opa | 99%  | 11  | 72  | 58  | 14  |
-| Containers with opa_layer | 99%  | 6  | 149  | 135  | 14  |
-| Containers with scrolling | 99%  | 11  | 81  | 62  | 19  |
-| Widgets demo | 99%  | 7  | 100  | 87  | 13  |
-| All scenes avg. | 99%  | 16  | 67  | 52  | 15  |
-
-
-
-<!-- END_BENCHMARK -->
+void app_main(void)
+{
+    bsp_spiffs_mount();
+    bsp_sdcard_mount();
+}
+```

--- a/bsp/esp32_c5_lcd_1_47/README.md
+++ b/bsp/esp32_c5_lcd_1_47/README.md
@@ -1,0 +1,125 @@
+# BSP: ESP32-S3-LCD-EV-Board
+
+| [HW Reference](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-lcd-ev-board/user_guide.html) | [HOW TO USE API](#api-reference) | [EXAMPLES](#compatible-bsp-examples) | [![Component Registry](https://components.espressif.com/components/espressif/esp32_s3_lcd_ev_board/badge.svg)](https://components.espressif.com/components/espressif/esp32_s3_lcd_ev_board) | ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg) |
+| --- | --- | --- | --- | -- |
+
+## Overview
+
+<table>
+<tr><td>
+
+ESP32-S3-LCD-EV-Board is a development board for evaluating and verifying ESP32-S3 screen interactive applications. It has the functions of touch screen interaction and voice interaction. The development board has the following characteristics:
+
+* Onboard ESP32-S3-WROOM-1 module, with built-in 16 MB Flash + 8/16 MB PSRAM
+* Onboard audio codec + audio amplifier
+* Onboard dual microphone pickup
+* USB type-C interface download and debugging
+* It can be used with different screen sub boards, and supports `RGB`, `8080`, `SPI`, `I2C` interface screens, as below:
+
+</td><td width="200">
+  <img src="doc/esp32_s3_lcd_ev_board.webp">
+  <img src="doc/esp32_s3_lcd_ev_board_2.webp">
+</td></tr>
+</table>
+
+
+|         Board Name         | Screen Size (inch) | Resolution | LCD Driver IC (Interface) | Touch Driver IC |                                                                            Schematic                                                                            | Support |
+| -------------------------- | ------------------ | ---------- | ------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| ESP32-S3-LCD-EV-Board-SUB1 | 0.9                | 128 x 64   | SSD1315 (I2C)             | *               | [link](https://docs.espressif.com/projects/esp-dev-kits/zh_CN/latest/_static/esp32-s3-lcd-ev-board/schematics/SCH_ESP32-S3-LCD-Ev-Board-SUB1_V1.0_20220617.pdf) | Not yet |
+|                            | 2.4                | 320 x 240  | ST7789V (SPI)             | XTP2046         |                                                                                                                                                                 | Not yet |
+| ESP32-S3-LCD-EV-Board-SUB2 | 3.5                | 480 x 320  | ST7796S (8080)            | GT911           | [link](https://docs.espressif.com/projects/esp-dev-kits/zh_CN/latest/_static/esp32-s3-lcd-ev-board/schematics/SCH_ESP32-S3-LCD-EV-Board-SUB2_V1.2_20230509.pdf) | Not yet |
+|                            | 3.95               | 480 x 480  | GC9503CV (RGB)            | FT5x06          |                                                                                                                                                                 | Yes     |
+| ESP32-S3-LCD-EV-Board-SUB3 | 4.3                | 800 x 480  | ST7262E43 (RGB)           | GT1151          | [link](https://docs.espressif.com/projects/esp-dev-kits/zh_CN/latest/_static/esp32-s3-lcd-ev-board/schematics/SCH_ESP32-S3-LCD-EV-Board-SUB3_V1.1_20230315.pdf) | Yes     |
+
+Here are some useful configurations in menuconfig that can be customed by user:
+
+* `BSP_LCD_RGB_BUFFER_NUMS`: Configure the number of frame buffers. The anti-tearing function can be activated only when set to a value greater than one.
+* `BSP_LCD_RGB_REFRESH_MODE`: Choose the refresh mode for the RGB LCD.
+    * `BSP_LCD_RGB_REFRESH_AUTO`: Use the most common method to refresh the LCD.
+    * `BSP_LCD_RGB_BOUNCE_BUFFER_MODE`: Enabling bounce buffer mode can lead to a higher PCLK frequency at the expense of increased CPU consumption. **This mode is particularly useful when dealing with [screen drift](https://docs.espressif.com/projects/esp-faq/en/latest/software-framework/peripherals/lcd.html#why-do-i-get-drift-overall-drift-of-the-display-when-esp32-s3-is-driving-an-rgb-lcd-screen), especially in scenarios involving Wi-Fi usage or writing to Flash memory.** This feature should be used in conjunction with `ESP32S3_DATA_CACHE_LINE_64B` configuration. For more detailed information, refer to the [documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/lcd.html#bounce-buffer-with-single-psram-frame-buffer).
+* `BSP_DISPLAY_LVGL_BUF_CAPS`: Select the memory type for the LVGL buffer. Internal memory offers better performance.
+* `BSP_DISPLAY_LVGL_BUF_HEIGHT`: Set the height of the LVGL buffer, with its width aligning with the LCD's width. The default value is 100, decreasing it can lower memory consumption.
+* `BSP_DISPLAY_LVGL_AVOID_TEAR`: Avoid tearing effect by using multiple buffers. This requires setting `BSP_LCD_RGB_BUFFER_NUMS` to a value greater than 1.
+    * `BSP_DISPLAY_LVGL_MODE`:
+        * `BSP_DISPLAY_LVGL_FULL_REFRESH`: Use LVGL full-refresh mode. Set `BSP_LCD_RGB_BUFFER_NUMS` to `3` will get higher FPS`.
+        * `BSP_DISPLAY_LVGL_DIRECT_MODE`: Use LVGL's direct mode.
+
+Based on the above configurations, there are three different anti-tearing modes can be used:
+
+* RGB double-buffer + LVGL full-refresh mode:
+    * Set `BSP_LCD_RGB_BUFFER_NUMS` to `2`
+    * Enable `BSP_DISPLAY_LVGL_AVOID_TEAR` and `BSP_DISPLAY_LVGL_FULL_REFRESH`
+* RGB double-buffer + LVGL direct-mode:
+    * Set `BSP_LCD_RGB_BUFFER_NUMS` to `2`
+    * Enable `BSP_DISPLAY_LVGL_AVOID_TEAR` and `BSP_DISPLAY_LVGL_DIRECT_MODE`
+* RGB triple-buffer + LVGL full-refresh mode:
+    * Set `BSP_LCD_RGB_BUFFER_NUMS` to `3`
+    * Enable `BSP_DISPLAY_LVGL_AVOID_TEAR` and `BSP_DISPLAY_LVGL_FULL_REFRESH`
+
+## Capabilities and dependencies
+
+<div align="center">
+<!-- START_DEPENDENCIES -->
+
+|     Available    |       Capability       |Controller/Codec|                                                                                                              Component                                                                                                              |      Version      |
+|------------------|------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+|:heavy_check_mark:|     :pager: DISPLAY    |                |[espressif/esp_lcd_gc9503](https://components.espressif.com/components/espressif/esp_lcd_gc9503)<br/>[espressif/esp_lcd_panel_io_additions](https://components.espressif.com/components/espressif/esp_lcd_panel_io_additions)<br/>idf|^3<br/>^1<br/>>=5.3|
+|:heavy_check_mark:|:black_circle: LVGL_PORT|                |                                                                    [espressif/esp_lvgl_port](https://components.espressif.com/components/espressif/esp_lvgl_port)                                                                   |         ^2        |
+|:heavy_check_mark:|    :point_up: TOUCH    |                |    [espressif/esp_lcd_touch_ft5x06](https://components.espressif.com/components/espressif/esp_lcd_touch_ft5x06)<br/>[espressif/esp_lcd_touch_gt1151](https://components.espressif.com/components/espressif/esp_lcd_touch_gt1151)    |     ^1<br/>^1     |
+|:heavy_check_mark:| :radio_button: BUTTONS |                |                                                                           [espressif/button](https://components.espressif.com/components/espressif/button)                                                                          |         ^4        |
+|:heavy_check_mark:|  :musical_note: AUDIO  |                |                                                                    [espressif/esp_codec_dev](https://components.espressif.com/components/espressif/esp_codec_dev)                                                                   |       ~1.3.1      |
+|:heavy_check_mark:| :speaker: AUDIO_SPEAKER|     es8311     |                                                                                                                                                                                                                                     |                   |
+|:heavy_check_mark:| :microphone: AUDIO_MIC |     es7210     |                                                                                                                                                                                                                                     |                   |
+|        :x:       |  :floppy_disk: SDCARD  |                |                                                                                                                                                                                                                                     |                   |
+|        :x:       |    :video_game: IMU    |                |                                                                                                                                                                                                                                     |                   |
+
+<!-- END_DEPENDENCIES -->
+</div>
+
+## Compatible BSP Examples
+
+<div align="center">
+<!-- START_EXAMPLES -->
+
+| Example | Description | Try with ESP Launchpad |
+| ------- | ----------- | ---------------------- |
+| [Display Example](https://github.com/espressif/esp-bsp/tree/master/examples/display) | Show an image on the screen with a simple startup animation (LVGL) | [Flash Example](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display) |
+| [Display, Audio and Photo Example](https://github.com/espressif/esp-bsp/tree/master/examples/display_audio_photo) | Complex demo: browse files from filesystem and play/display JPEG, WAV, or TXT files (LVGL) | [Flash Example](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_audio_photo) |
+| [LVGL Benchmark Example](https://github.com/espressif/esp-bsp/tree/master/examples/display_lvgl_benchmark) | Run LVGL benchmark tests | - |
+| [LVGL Demos Example](https://github.com/espressif/esp-bsp/tree/master/examples/display_lvgl_demos) | Run the LVGL demo player - all LVGL examples are included (LVGL) | [Flash Example](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_lvgl_demo) |
+| [Display Rotation Example](https://github.com/espressif/esp-bsp/tree/master/examples/display_rotation) | Rotate screen using buttons or an accelerometer (`BSP_CAPS_IMU`, if available) | [Flash Example](https://espressif.github.io/esp-launchpad/?flashConfigURL=https://espressif.github.io/esp-bsp/config.toml&app=display_rotation) |
+
+<!-- END_EXAMPLES -->
+</div>
+
+<!-- START_BENCHMARK -->
+
+## LVGL Benchmark
+
+**DATE:** 08.07.2025 10:31
+
+**LVGL version:** 9.3.0
+
+| Name | Avg. CPU | Avg. FPS | Avg. time | render time | flush time |
+| ---- | :------: | :------: | :-------: | :---------: | :--------: |
+| Empty screen | 98%  | 18  | 51  | 30  | 21  |
+| Moving wallpaper | 100%  | 8  | 109  | 84  | 25  |
+| Single rectangle | 99%  | 35  | 24  | 1  | 23  |
+| Multiple rectangles | 99%  | 32  | 27  | 18  | 9  |
+| Multiple RGB images | 99%  | 28  | 29  | 22  | 7  |
+| Multiple ARGB images | 99%  | 16  | 51  | 36  | 15  |
+| Rotated ARGB images | 100%  | 15  | 59  | 51  | 8  |
+| Multiple labels | 99%  | 18  | 47  | 35  | 12  |
+| Screen sized text | 100%  | 8  | 110  | 91  | 19  |
+| Multiple arcs | 99%  | 35  | 23  | 8  | 15  |
+| Containers | 99%  | 14  | 56  | 41  | 15  |
+| Containers with overlay | 99%  | 9  | 87  | 75  | 12  |
+| Containers with opa | 99%  | 11  | 72  | 58  | 14  |
+| Containers with opa_layer | 99%  | 6  | 149  | 135  | 14  |
+| Containers with scrolling | 99%  | 11  | 81  | 62  | 19  |
+| Widgets demo | 99%  | 7  | 100  | 87  | 13  |
+| All scenes avg. | 99%  | 16  | 67  | 52  | 15  |
+
+
+
+<!-- END_BENCHMARK -->

--- a/bsp/esp32_c5_lcd_1_47/esp32_c5_lcd_1_47.c
+++ b/bsp/esp32_c5_lcd_1_47/esp32_c5_lcd_1_47.c
@@ -1,0 +1,497 @@
+/*
+ * SPDX-FileCopyrightText: 2026-2027 Waveshare Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdio.h>
+#include "driver/i2c_master.h"
+#include "driver/gpio.h"
+#include "driver/ledc.h"
+#include "esp_err.h"
+#include "esp_vfs_fat.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_panel_vendor.h"
+#include "esp_log.h"
+#include "esp_spiffs.h"
+
+// #include "esp_lcd_st7789.h"
+
+#include "bsp/esp32_c5_lcd_1_47.h"
+#include "bsp/touch.h"
+#include "bsp_err_check.h"
+#include "bsp/config.h"
+#include "bsp/display.h"
+
+#include "lvgl.h"
+#include "esp_lvgl_port.h"
+
+
+static const char *TAG = "ESP32-C5-LCD-1.47";
+
+/**
+ * @brief I2C handle for BSP usage
+ *
+ * In IDF v5.4 you can call i2c_master_get_bus_handle(BSP_I2C_NUM, i2c_master_bus_handle_t *ret_handle)
+ * from #include "esp_private/i2c_platform.h" to get this handle
+ *
+ * For IDF 5.2 and 5.3 you must call bsp_i2c_get_handle()
+ */
+static i2c_master_bus_handle_t i2c_handle = NULL;
+static bool i2c_initialized = false;
+
+static bool spi_initialized = false;
+
+sdmmc_host_t host = SDSPI_HOST_DEFAULT();
+sdmmc_card_t *bsp_sdcard = NULL; // Global uSD card handler
+
+static lv_display_t *disp;
+static esp_lcd_panel_handle_t panel_handle = NULL; // LCD panel handle
+static esp_lcd_panel_io_handle_t io_handle = NULL;
+
+static led_strip_handle_t led_strip;
+
+uint8_t brightness;
+
+/**************************************************************************************************
+ *
+ * I2C Function
+ *
+ **************************************************************************************************/
+esp_err_t bsp_i2c_init(void)
+{
+    /* I2C was initialized before */
+    if (i2c_initialized) {
+        return ESP_OK;
+    }
+
+    i2c_master_bus_config_t i2c_config = {
+        .i2c_port = BSP_I2C_NUM,
+        .sda_io_num = BSP_I2C_SDA,
+        .scl_io_num = BSP_I2C_SCL,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+    };
+
+    BSP_ERROR_CHECK_RETURN_ERR(i2c_new_master_bus(&i2c_config, &i2c_handle));
+
+    i2c_initialized = true;
+    return ESP_OK;
+}
+
+esp_err_t bsp_i2c_deinit(void)
+{
+    BSP_ERROR_CHECK_RETURN_ERR(i2c_del_master_bus(i2c_handle));
+    i2c_initialized = false;
+    return ESP_OK;
+}
+
+i2c_master_bus_handle_t bsp_i2c_get_handle(void)
+{
+    bsp_i2c_init();
+    return i2c_handle;
+}
+
+/**************************************************************************************************
+ *
+ * SPI Function
+ *
+ **************************************************************************************************/
+esp_err_t bsp_spi_init(void)
+{
+    /* SPI was initialized before */
+    if (spi_initialized) {
+        return ESP_OK;
+    }
+
+    spi_bus_config_t bus_cfg = {
+        .mosi_io_num = BSP_SD_CMD,
+        .miso_io_num = BSP_SD_D0,
+        .sclk_io_num = BSP_SD_CLK,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+        // Reserve enough DMA transfer space for a full-screen LCD transaction.
+        .max_transfer_sz = BSP_LCD_H_RES * BSP_LCD_V_RES * BSP_LCD_BITS_PER_PIXEL / 8,
+    };
+
+    BSP_ERROR_CHECK_RETURN_ERR(spi_bus_initialize(host.slot, &bus_cfg, SPI_DMA_CH_AUTO));
+    spi_initialized = true;
+    return ESP_OK;
+}
+
+/**************************************************************************************************
+ *
+ * SPIFFS Function
+ *
+ **************************************************************************************************/
+esp_err_t bsp_spiffs_mount(void)
+{
+    esp_vfs_spiffs_conf_t conf = {
+        .base_path = CONFIG_BSP_SPIFFS_MOUNT_POINT,
+        .partition_label = CONFIG_BSP_SPIFFS_PARTITION_LABEL,
+        .max_files = CONFIG_BSP_SPIFFS_MAX_FILES,
+#ifdef CONFIG_BSP_SPIFFS_FORMAT_ON_MOUNT_FAIL
+        .format_if_mount_failed = true,
+#else
+        .format_if_mount_failed = false,
+#endif
+    };
+
+    esp_err_t ret_val = esp_vfs_spiffs_register(&conf);
+
+    BSP_ERROR_CHECK_RETURN_ERR(ret_val);
+
+    size_t total = 0, used = 0;
+    ret_val = esp_spiffs_info(conf.partition_label, &total, &used);
+    if (ret_val != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get SPIFFS partition information (%s)", esp_err_to_name(ret_val));
+    } else {
+        ESP_LOGI(TAG, "Partition size: total: %d, used: %d", total, used);
+    }
+
+    return ret_val;
+}
+
+esp_err_t bsp_spiffs_unmount(void)
+{
+    return esp_vfs_spiffs_unregister(CONFIG_BSP_SPIFFS_PARTITION_LABEL);
+}
+
+/**************************************************************************************************
+ *
+ * SD Function
+ *
+ **************************************************************************************************/
+esp_err_t bsp_sdcard_mount(void)
+{
+    if (!spi_initialized) {
+        bsp_spi_init();
+    }
+
+    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+#ifdef CONFIG_EXAMPLE_FORMAT_IF_MOUNT_FAILED
+        .format_if_mount_failed = true,
+#else
+        .format_if_mount_failed = false,
+#endif // EXAMPLE_FORMAT_IF_MOUNT_FAILED
+        .max_files = 5,
+        .allocation_unit_size = 16 * 1024
+    };
+
+    // This initializes the slot without card detect (CD) and write protect (WP) signals.
+    // Modify slot_config.gpio_cd and slot_config.gpio_wp if your board has these signals.
+    sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
+    slot_config.gpio_cs = BSP_SD_CS;
+    slot_config.host_id = host.slot;
+
+    ESP_LOGI(TAG, "Mounting filesystem");
+    esp_err_t ret = esp_vfs_fat_sdspi_mount(BSP_SD_MOUNT_POINT, &host, &slot_config, &mount_config, &bsp_sdcard);
+    if (ret != ESP_OK) {
+        if (ret == ESP_FAIL) {
+            ESP_LOGE(TAG, "Failed to mount filesystem. "
+                     "If you want the card to be formatted, set the CONFIG_EXAMPLE_FORMAT_IF_MOUNT_FAILED menuconfig option.");
+        } else {
+            ESP_LOGE(TAG, "Failed to initialize the card (%s). "
+                     "Make sure SD card lines have pull-up resistors in place.", esp_err_to_name(ret));
+#ifdef CONFIG_EXAMPLE_DEBUG_PIN_CONNECTIONS
+            check_sd_card_pins(&config, pin_count);
+#endif
+        }
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "Filesystem mounted");
+    return ESP_OK;
+}
+
+esp_err_t bsp_sdcard_unmount(void)
+{
+    return esp_vfs_fat_sdcard_unmount(BSP_SD_MOUNT_POINT, bsp_sdcard);
+}
+
+/**********************************************************************************************************
+ *
+ * Display Function
+ *
+ **********************************************************************************************************/
+#if LVGL_VERSION_MAJOR >= 9
+static void rounder_event_cb(lv_event_t *e)
+{
+    lv_area_t *area = (lv_area_t *)lv_event_get_param(e);
+    uint16_t x1 = area->x1;
+    uint16_t x2 = area->x2;
+
+    uint16_t y1 = area->y1;
+    uint16_t y2 = area->y2;
+
+    // round the start of coordinate down to the nearest 2M number
+    area->x1 = (x1 >> 1) << 1;
+    area->y1 = (y1 >> 1) << 1;
+    // round the end of coordinate up to the nearest 2N+1 number
+    area->x2 = ((x2 >> 1) << 1) + 1;
+    area->y2 = ((y2 >> 1) << 1) + 1;
+}
+#else
+static void bsp_lvgl_rounder_cb(lv_disp_drv_t *disp_drv, lv_area_t *area)
+{
+    uint16_t x1 = area->x1;
+    uint16_t x2 = area->x2;
+
+    uint16_t y1 = area->y1;
+    uint16_t y2 = area->y2;
+
+    // round the start of coordinate down to the nearest 2M number
+    area->x1 = (x1 >> 1) << 1;
+    area->y1 = (y1 >> 1) << 1;
+    // round the end of coordinate up to the nearest 2N+1 number
+    area->x2 = ((x2 >> 1) << 1) + 1;
+    area->y2 = ((y2 >> 1) << 1) + 1;
+}
+#endif
+
+esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
+{
+    esp_err_t ret = ESP_OK;
+
+    if (!spi_initialized) {
+        ESP_LOGI(TAG, "Initialize SPI bus");
+        bsp_spi_init();
+    }
+
+    const esp_lcd_panel_io_spi_config_t io_config = {
+        .dc_gpio_num = BSP_LCD_DC,
+        .cs_gpio_num = BSP_LCD_CS,
+        .pclk_hz = BSP_LCD_SPI_CLK_HZ,
+        .lcd_cmd_bits = 8,
+        .lcd_param_bits = 8,
+        .spi_mode = 0,
+        .trans_queue_depth = 10,
+    };
+    // Attach the LCD to the SPI bus
+    ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi(host.slot,
+                                             &io_config, &io_handle));
+
+    esp_lcd_panel_dev_config_t panel_config = {
+        .reset_gpio_num = BSP_LCD_RST,
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,
+        .bits_per_pixel = BSP_LCD_BITS_PER_PIXEL,
+        .flags = {.reset_active_high = 0}
+    };
+
+    ESP_LOGI(TAG, "Install ST7789 panel driver");
+    ESP_ERROR_CHECK(
+        esp_lcd_new_panel_st7789(io_handle, &panel_config, &panel_handle));
+
+    ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_handle));
+    ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
+    esp_lcd_panel_disp_on_off(panel_handle, true);
+    ESP_ERROR_CHECK(esp_lcd_panel_invert_color(panel_handle, true));
+    ESP_ERROR_CHECK(esp_lcd_panel_set_gap(panel_handle, 34, 0));
+
+    if (ret_panel)
+    {
+        *ret_panel = panel_handle;
+    }
+    if (ret_io)
+    {
+        *ret_io = io_handle;
+    }
+    return ret;
+}
+
+static lv_display_t *bsp_display_lcd_init()
+{
+    bsp_display_config_t disp_config = {0};
+
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&disp_config, &panel_handle, &io_handle));
+
+    int buffer_size = 0;
+    buffer_size = BSP_LCD_H_RES * CONFIG_BSP_DISPLAY_LVGL_BUF_HEIGHT;
+
+    const lvgl_port_display_cfg_t disp_cfg = {
+        .io_handle = io_handle,
+        .panel_handle = panel_handle,
+        .buffer_size = buffer_size,
+
+        .monochrome = false,
+        .hres = BSP_LCD_H_RES,
+        .vres = BSP_LCD_V_RES,
+#if LVGL_VERSION_MAJOR >= 9
+        .color_format = LV_COLOR_FORMAT_RGB565,
+#endif
+
+        .rotation = {
+            .swap_xy = false,
+            .mirror_x = false,
+            .mirror_y = false,
+        },
+        .flags = {
+            .sw_rotate = true,
+            .buff_dma = false,
+            .buff_spiram = false,
+            .full_refresh = 0,
+            .direct_mode = 0,
+#if LVGL_VERSION_MAJOR >= 9
+            .swap_bytes = true,
+#endif
+        }};
+
+    lv_display_t *disp = lvgl_port_add_disp(&disp_cfg);
+    if (!disp)
+    {
+        return NULL;
+    }
+
+    return disp;
+}
+
+lv_display_t *bsp_display_start(void)
+{
+    bsp_display_cfg_t cfg = {
+        .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG(),
+        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
+        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
+        .flags = {
+            .buff_dma = true,
+            .buff_spiram = false,
+        }};
+    return bsp_display_start_with_config(&cfg);
+}
+
+lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
+{
+    lv_display_t *disp;
+
+    assert(cfg != NULL);
+    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
+
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
+
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
+
+    return disp;
+}
+#define LCD_LEDC_CH            CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH
+
+esp_err_t bsp_display_brightness_init(void)
+{
+    const ledc_channel_config_t LCD_backlight_channel = {
+        .gpio_num = BSP_LCD_BACKLIGHT,
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .channel = LCD_LEDC_CH,
+        .intr_type = LEDC_INTR_DISABLE,
+        .timer_sel = 1,
+        .duty = 0,
+        .hpoint = 0
+    };
+    const ledc_timer_config_t LCD_backlight_timer = {
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .duty_resolution = LEDC_TIMER_10_BIT,
+        .timer_num = 1,
+        .freq_hz = 5000,
+        .clk_cfg = LEDC_AUTO_CLK
+    };
+
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_timer_config(&LCD_backlight_timer));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_channel_config(&LCD_backlight_channel));
+
+    return ESP_OK;
+}
+
+esp_err_t bsp_display_brightness_set(int brightness_percent)
+{
+    if (brightness_percent > 100) {
+        brightness_percent = 100;
+    } else if (brightness_percent < 0) {
+        brightness_percent = 0;
+    }
+
+    int flipped_brightness = brightness_percent;
+
+    brightness = (uint8_t)flipped_brightness;
+
+    ESP_LOGI(TAG, "Setting flipped LCD backlight: %d%% (original: %d%%)", flipped_brightness, brightness_percent);
+
+    uint32_t duty_cycle = (1023 * flipped_brightness) / 100;
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_set_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH, duty_cycle));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_update_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH));
+
+    return ESP_OK;
+}
+
+int bsp_display_brightness_get(void)
+{
+    if (panel_handle == NULL)
+    {
+        ESP_LOGE(TAG, "Panel handle is not initialized");
+        return -1;
+    }
+
+    return brightness * 100 / 255;
+}
+
+esp_err_t bsp_display_backlight_off(void)
+{
+    return bsp_display_brightness_set(0);
+}
+
+esp_err_t bsp_display_backlight_on(void)
+{
+    return bsp_display_brightness_set(100);
+}
+
+
+void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation)
+{
+    lv_disp_set_rotation(disp, rotation);
+}
+
+bool bsp_display_lock(uint32_t timeout_ms)
+{
+    return lvgl_port_lock(timeout_ms);
+}
+
+void bsp_display_unlock(void)
+{
+    lvgl_port_unlock();
+}
+
+/**************************************************************************************************
+ *
+ * WS2812B Function
+ *
+ **************************************************************************************************/
+esp_err_t bsp_ws2812b_init()
+{
+    // LED strip general initialization, according to your led board design
+    led_strip_config_t strip_config = {
+        .strip_gpio_num = BSP_WS2812_PIN, // The GPIO that connected to the LED strip's data line
+        .max_leds = LED_STRIP_LED_COUNT,      // The number of LEDs in the strip,
+        .led_model = LED_MODEL_WS2812,        // LED strip model
+        .color_component_format = LED_STRIP_COLOR_COMPONENT_FMT_RGB, // The color order of the onboard LED: RGB
+        .flags = {
+            .invert_out = false, // don't invert the output signal
+        }
+    };
+
+    // LED strip backend configuration: RMT
+    led_strip_rmt_config_t rmt_config = {
+        .clk_src = RMT_CLK_SRC_DEFAULT,        // different clock source can lead to different power consumption
+        .resolution_hz = LED_STRIP_RMT_RES_HZ, // RMT counter clock frequency
+        .mem_block_symbols = LED_STRIP_MEMORY_BLOCK_WORDS, // the memory block size used by the RMT channel
+        .flags = {
+            .with_dma = 0,     // Using DMA can improve performance when driving more LEDs
+        }
+    };
+
+    // LED Strip object handle
+    ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip));
+    ESP_LOGI(TAG, "Created LED strip object with RMT backend");
+
+    return ESP_OK;
+}
+
+esp_err_t bsp_setledcolor(int index, uint8_t red, uint8_t green, uint8_t blue) {
+    esp_err_t ret = ESP_OK;
+    ESP_ERROR_CHECK(led_strip_set_pixel(led_strip, index, red, green, blue));
+    ret |= led_strip_refresh(led_strip);
+    return ret;
+}

--- a/bsp/esp32_c5_lcd_1_47/esp32_c5_lcd_1_47.c
+++ b/bsp/esp32_c5_lcd_1_47/esp32_c5_lcd_1_47.c
@@ -297,19 +297,18 @@ esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_hand
     return ret;
 }
 
-static lv_display_t *bsp_display_lcd_init()
+static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
 {
+    assert(cfg != NULL);
     bsp_display_config_t disp_config = {0};
 
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(&disp_config, &panel_handle, &io_handle));
 
-    int buffer_size = 0;
-    buffer_size = BSP_LCD_H_RES * CONFIG_BSP_DISPLAY_LVGL_BUF_HEIGHT;
-
     const lvgl_port_display_cfg_t disp_cfg = {
         .io_handle = io_handle,
         .panel_handle = panel_handle,
-        .buffer_size = buffer_size,
+        .buffer_size = cfg->buffer_size,
+        .double_buffer = cfg->double_buffer,
 
         .monochrome = false,
         .hres = BSP_LCD_H_RES,
@@ -325,8 +324,8 @@ static lv_display_t *bsp_display_lcd_init()
         },
         .flags = {
             .sw_rotate = true,
-            .buff_dma = false,
-            .buff_spiram = false,
+            .buff_dma = cfg->flags.buff_dma,
+            .buff_spiram = cfg->flags.buff_spiram,
             .full_refresh = 0,
             .direct_mode = 0,
 #if LVGL_VERSION_MAJOR >= 9

--- a/bsp/esp32_c5_lcd_1_47/idf_component.yml
+++ b/bsp/esp32_c5_lcd_1_47/idf_component.yml
@@ -5,7 +5,7 @@ dependencies:
   espressif/esp_lvgl_port:
     public: true
     version: ^2
-  lvgl/lvgl: '>=8,<10' 
+  lvgl/lvgl: '>=8,<10'
   idf: '>=5.3'
 description: Board Support Package (BSP) for ESP32-C5-LCD-1.47
 repository: git://github.com/espressif/esp-bsp.git

--- a/bsp/esp32_c5_lcd_1_47/idf_component.yml
+++ b/bsp/esp32_c5_lcd_1_47/idf_component.yml
@@ -1,0 +1,17 @@
+dependencies:
+  espressif/led_strip:
+    public: true
+    version: '*'
+  espressif/esp_lvgl_port:
+    public: true
+    version: ^2
+  lvgl/lvgl: '>=8,<10' 
+  idf: '>=5.3'
+description: Board Support Package (BSP) for ESP32-C5-LCD-1.47
+repository: git://github.com/espressif/esp-bsp.git
+tags:
+- bsp
+targets:
+- esp32c5
+url: https://github.com/waveshareteam/Waveshare-ESP32-components
+version: 1.0.0

--- a/bsp/esp32_c5_lcd_1_47/include/bsp/config.h
+++ b/bsp/esp32_c5_lcd_1_47/include/bsp/config.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026-2027 Waveshare Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/**************************************************************************************************
+ * BSP configuration
+ **************************************************************************************************/
+// By default, this BSP is shipped with LVGL graphical library. Enabling this option will exclude it.
+// If you want to use BSP without LVGL, select BSP version with 'noglib' suffix.
+#if !defined(BSP_CONFIG_NO_GRAPHIC_LIB) // Check if the symbol is not coming from compiler definitions (-D...)
+#define BSP_CONFIG_NO_GRAPHIC_LIB (0)
+#endif

--- a/bsp/esp32_c5_lcd_1_47/include/bsp/display.h
+++ b/bsp/esp32_c5_lcd_1_47/include/bsp/display.h
@@ -1,0 +1,117 @@
+
+
+#pragma once
+#include "esp_lcd_types.h"
+
+/* LCD color formats */
+#define ESP_LCD_COLOR_FORMAT_RGB565    (1)
+#define ESP_LCD_COLOR_FORMAT_RGB888    (2)
+
+/* LCD display color format */
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
+/* LCD display color bytes endianess */
+#define BSP_LCD_BIGENDIAN           (0)
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+/* LCD display color space */
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+/* LCD display definition */
+#define BSP_LCD_H_RES              (172)
+#define BSP_LCD_V_RES              (320)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief BSP display configuration structure
+ *
+ */
+typedef struct {
+    int max_transfer_sz;    /*!< Maximum transfer size, in bytes. */
+} bsp_display_config_t;
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_io_del(io);
+ * spi_bus_free(spi_num_from_configuration);
+ * \endcode
+ *
+ * @param[in]  config    display configuration
+ * @param[out] ret_panel esp_lcd panel handle
+ * @param[out] ret_io    esp_lcd IO handle
+ * @return
+ *      - ESP_OK         On success
+ *      - Else           esp_lcd failure
+ */
+esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Initialize display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_init(void);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Brightness must be already initialized by calling bsp_display_brightness_init() or bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+/**
+ * @brief Get display's brightness
+ *
+ * @return
+ *      - Brightness in [%]
+ */
+int bsp_display_brightness_get(void);
+
+/**
+ * @brief Turn on display backlight
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Brightness must be already initialized by calling bsp_display_brightness_init() or bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Brightness must be already initialized by calling bsp_display_brightness_init() or bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bsp/esp32_c5_lcd_1_47/include/bsp/esp-bsp.h
+++ b/bsp/esp32_c5_lcd_1_47/include/bsp/esp-bsp.h
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2026-2027 Waveshare Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+#include "bsp/esp32_c5_lcd_1_47.h"

--- a/bsp/esp32_c5_lcd_1_47/include/bsp/esp32_c5_lcd_1_47.h
+++ b/bsp/esp32_c5_lcd_1_47/include/bsp/esp32_c5_lcd_1_47.h
@@ -1,0 +1,372 @@
+/*
+ * SPDX-FileCopyrightText: 2026-2027 Waveshare Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ESP BSP: ESP32-C5-LCD-1.47
+ */
+
+#pragma once
+
+#include "sdkconfig.h"
+#include "driver/i2c_master.h"
+#include "driver/gpio.h"
+#include "sdmmc_cmd.h"
+#include "esp_err.h"
+#include "led_strip.h"
+
+#include "bsp/config.h"
+#include "bsp/display.h"
+
+#include "lvgl.h"
+#include "esp_lvgl_port.h"
+
+/**************************************************************************************************
+ *  BSP Capabilities
+ **************************************************************************************************/
+
+/** @defgroup capabilities Capabilities
+ *  @brief BSP Capabilities
+ *  @{
+ */
+#define BSP_CAPS_DISPLAY 1
+#define BSP_CAPS_TOUCH 0
+#define BSP_CAPS_BUTTONS 0
+#define BSP_CAPS_AUDIO 0
+#define BSP_CAPS_AUDIO_SPEAKER 0
+#define BSP_CAPS_AUDIO_MIC 0
+#define BSP_CAPS_SDCARD 1
+#define BSP_CAPS_IMU 0
+#define BSP_CAPS_WS2812 1
+/** @} */ // end of capabilities
+
+/**************************************************************************************************
+ *  ESP32-C5-LCD-1.47 Pinout
+ **************************************************************************************************/
+/** @defgroup g01_i2c I2C
+ *  @brief I2C BSP API
+ *  @{
+ */
+#define BSP_I2C_SCL (GPIO_NUM_NC)
+#define BSP_I2C_SDA (GPIO_NUM_NC)
+
+/** @} */ // end of i2c
+
+/** @defgroup g03_audio Audio
+ *  @brief Audio BSP API
+ *  @{
+ */
+#define BSP_I2S_SCLK (GPIO_NUM_NC)
+#define BSP_I2S_MCLK (GPIO_NUM_NC)
+#define BSP_I2S_LCLK (GPIO_NUM_NC)
+#define BSP_I2S_DOUT (GPIO_NUM_NC) // To Codec ES8311
+#define BSP_I2S_DSIN (GPIO_NUM_NC) // From ADC ES7210
+#define BSP_POWER_AMP_IO (GPIO_NUM_NC)
+/** @} */ // end of audio
+
+/** @defgroup g04_display Display and Touch
+ *  @brief Display BSP API
+ *  @{
+ */
+/* Display */
+#define BSP_LCD_CS   (GPIO_NUM_23) 
+#define BSP_LCD_CLK  (GPIO_NUM_7)
+#define BSP_LCD_DATA (GPIO_NUM_6)
+#define BSP_LCD_DC   (GPIO_NUM_24)
+
+#define BSP_LCD_BACKLIGHT (GPIO_NUM_10)
+#define BSP_LCD_RST       (GPIO_NUM_26)
+
+/** @} */ // end of display
+
+/* uSD card */
+#define BSP_SD_D0  (GPIO_NUM_5)
+#define BSP_SD_CMD (GPIO_NUM_6)
+#define BSP_SD_CLK (GPIO_NUM_7)
+#define BSP_SD_CS  (GPIO_NUM_4)
+
+/** @} */ // end of uSD card
+
+/* WS2812B */
+#define BSP_WS2812_PIN           (GPIO_NUM_8)
+// 10MHz resolution, 1 tick = 0.1us (led strip needs a high resolution)
+#define LED_STRIP_RMT_RES_HZ  (10 * 1000 * 1000)
+// Numbers of the LED in the strip
+#define LED_STRIP_LED_COUNT 1
+#define LED_STRIP_MEMORY_BLOCK_WORDS 0 // let the driver choose a proper memory block size automatically
+
+/** @} */ // end of WS2812
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/** \addtogroup g01_i2c
+ *  @{
+ */
+
+/**************************************************************************************************
+ *
+ * I2C Interface
+ *
+ * There are multiple devices connected to I2C peripheral:
+ *  - Codec ES8311 (configuration only)
+ *  - ADC ES7210 (configuration only)
+ *  - LCD Touch controller
+ *  - IO expander chip TCA9554
+ **************************************************************************************************/
+#define BSP_I2C_NUM (CONFIG_BSP_I2C_NUM)
+
+    /**
+     * @brief Init I2C driver
+     *
+     * @return
+     *      - ESP_OK:               On success
+     *      - ESP_ERR_INVALID_ARG:  I2C parameter error
+     *      - ESP_FAIL:             I2C driver installation error
+     *
+     */
+    esp_err_t bsp_i2c_init(void);
+
+    /**
+     * @brief Deinit I2C driver and free its resources
+     *
+     * @return
+     *      - ESP_OK:               On success
+     *      - ESP_ERR_INVALID_ARG:  I2C parameter error
+     *
+     */
+    esp_err_t bsp_i2c_deinit(void);
+
+    /**
+     * @brief Get I2C driver handle
+     *
+     * @return
+     *      - I2C handle
+     */
+    i2c_master_bus_handle_t bsp_i2c_get_handle(void);
+
+/** @} */ // end of i2c
+
+/** @defgroup g02_storage SD Card and SPIFFS
+ *  @brief SPIFFS and SD card BSP API
+ *  @{
+ */
+
+/**************************************************************************************************
+ *
+ * SPIFFS
+ *
+ * After mounting the SPIFFS, it can be accessed with stdio functions ie.:
+ * \code{.c}
+ * FILE* f = fopen(BSP_SPIFFS_MOUNT_POINT"/hello.txt", "w");
+ * fprintf(f, "Hello World!\n");
+ * fclose(f);
+ * \endcode
+ **************************************************************************************************/
+#define BSP_SPIFFS_MOUNT_POINT CONFIG_BSP_SPIFFS_MOUNT_POINT
+
+    /**
+     * @brief Mount SPIFFS to virtual file system
+     *
+     * @return
+     *      - ESP_OK on success
+     *      - ESP_ERR_INVALID_STATE if esp_vfs_spiffs_register was already called
+     *      - ESP_ERR_NO_MEM if memory can not be allocated
+     *      - ESP_FAIL if partition can not be mounted
+     *      - other error codes
+     */
+    esp_err_t bsp_spiffs_mount(void);
+
+    /**
+     * @brief Unmount SPIFFS from virtual file system
+     *
+     * @return
+     *      - ESP_OK on success
+     *      - ESP_ERR_NOT_FOUND if the partition table does not contain SPIFFS partition with given label
+     *      - ESP_ERR_INVALID_STATE if esp_vfs_spiffs_unregister was already called
+     *      - ESP_ERR_NO_MEM if memory can not be allocated
+     *      - ESP_FAIL if partition can not be mounted
+     *      - other error codes
+     */
+    esp_err_t bsp_spiffs_unmount(void);
+
+/** @} */ // end of storage
+
+/**************************************************************************************************
+ *
+ * uSD card
+ *
+ * After mounting the uSD card, it can be accessed with stdio functions ie.:
+ * \code{.c}
+ * FILE* f = fopen(BSP_MOUNT_POINT"/hello.txt", "w");
+ * fprintf(f, "Hello %s!\n", bsp_sdcard->cid.name);
+ * fclose(f);
+ * \endcode
+ **************************************************************************************************/
+#define BSP_SD_MOUNT_POINT CONFIG_BSP_SD_MOUNT_POINT
+    extern sdmmc_card_t *bsp_sdcard;
+
+    /**
+     * @brief Mount microSD card to virtual file system
+     *
+     * @return
+     *      - ESP_OK on success
+     *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_sdmmc_mount was already called
+     *      - ESP_ERR_NO_MEM if memory cannot be allocated
+     *      - ESP_FAIL if partition cannot be mounted
+     *      - other error codes from SDMMC or SPI drivers, SDMMC protocol, or FATFS drivers
+     */
+    esp_err_t bsp_sdcard_mount(void);
+
+    /**
+     * @brief Unmount microSD card from virtual file system
+     *
+     * @return
+     *      - ESP_OK on success
+     *      - ESP_ERR_NOT_FOUND if the partition table does not contain FATFS partition with given label
+     *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_spiflash_mount was already called
+     *      - ESP_ERR_NO_MEM if memory can not be allocated
+     *      - ESP_FAIL if partition can not be mounted
+     *      - other error codes from wear levelling library, SPI flash driver, or FATFS drivers
+     */
+    esp_err_t bsp_sdcard_unmount(void);
+
+/** @defgroup g99_others Others
+ *  @brief Other BSP API
+ *  @{
+ */
+
+
+/**************************************************************************************************
+ *
+ * LCD interface
+ *
+ * LVGL is used as graphics library. LVGL is NOT thread safe, therefore the user must take LVGL mutex
+ * by calling bsp_display_lock() before calling any LVGL API (lv_...) and then give the mutex with
+ * bsp_display_unlock().
+ *
+ * If you want to use the display without LVGL, see bsp/display.h API and use BSP version with 'noglib' suffix.
+ **************************************************************************************************/
+#define BSP_LCD_SPI_NUM            (SPI2_HOST)
+#define BSP_LCD_SPI_CLK_HZ         (40 * 1000 * 1000)
+
+#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * CONFIG_BSP_LCD_RGB_BOUNCE_BUFFER_HEIGHT)
+#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
+
+    /**
+     * @brief BSP display configuration structure
+     *
+     */
+    typedef struct {
+        lvgl_port_cfg_t lvgl_port_cfg;  /*!< LVGL port configuration */
+        uint32_t        buffer_size;    /*!< Size of the buffer for the screen in pixels */
+        uint32_t        trans_size;
+        bool            double_buffer;  /*!< True, if should be allocated two buffers */
+        struct {
+            unsigned int buff_dma: 1;    /*!< Allocated LVGL buffer will be DMA capable */
+            unsigned int buff_spiram: 1; /*!< Allocated LVGL buffer will be in PSRAM */
+        } flags;
+    } bsp_display_cfg_t;
+
+    /**
+     * @brief Initialize display
+     *
+     * @note This function initializes display controller and starts LVGL handling task.
+     * @note Users can get LCD panel handle from `user_data` in returned display.
+     *
+     * @return Pointer to LVGL display or NULL when error occurred
+     */
+    lv_display_t *bsp_display_start(void);
+
+    /**
+     * @brief Initialize display
+     *
+     * This function initializes SPI, display controller and starts LVGL handling task.
+     * LCD backlight must be enabled separately by calling `bsp_display_brightness_set()`
+     *
+     * @param cfg display configuration
+     *
+     * @return Pointer to LVGL display or NULL when error occurred
+     */
+    lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg);
+
+    /**
+     * @brief Get pointer to input device (touch, buttons, ...)
+     *
+     * @note  The LVGL input device is initialized in `bsp_display_start()` function.
+     * @note  This function should be called after calling `bsp_display_start()`.
+     *
+     * @return Pointer to LVGL input device or NULL when not initialized
+     */
+    lv_indev_t *bsp_display_get_input_dev(void);
+
+    /**
+     * @brief Take LVGL mutex
+     *
+     * @note  Display must be already initialized by calling `bsp_display_start()`
+     *
+     * @param[in] timeout_ms: Timeout in [ms]. 0 will block indefinitely.
+     *
+     * @return
+     *      - true:  Mutex was taken
+     *      - false: Mutex was NOT taken
+     */
+    bool bsp_display_lock(uint32_t timeout_ms);
+
+    /**
+     * @brief Give LVGL mutex
+     *
+     * @note  Display must be already initialized by calling `bsp_display_start()`
+     *
+     */
+    void bsp_display_unlock(void);
+
+    /**
+     * @brief Rotate screen
+     *
+     * @note  Display must be already initialized by calling `bsp_display_start()`
+     * @note  This function can't work with the anti-tearing function. Please use the `BSP_DISPLAY_LVGL_ROTATION` configuration instead.
+     *
+     * @param[in] disp:     Pointer to LVGL display
+     * @param[in] rotation: Angle of the display rotation
+     */
+    void bsp_display_rotate(lv_display_t *disp, lv_display_rotation_t rotation);
+
+    /**
+     * @brief Initialize the WS2812B LED strip
+     *
+     * This function initializes the WS2812B driver and prepares the LED strip
+     * for subsequent color control.
+     *
+     * @return
+     *      - ESP_OK: Initialization succeeded.
+     *      - ESP_FAIL: Initialization failed.
+     */
+    esp_err_t bsp_ws2812b_init();
+
+    /**
+     * @brief Set the color of a specific WS2812B LED
+     *
+     * This function sets the color of the LED at the given index in the LED strip.
+     *
+     * @param[in] index   The LED index to set (0-based).
+     * @param[in] g       Green component (0-255).
+     * @param[in] r       Red component (0-255).
+     * @param[in] b       Blue component (0-255).
+     *
+     * @return
+     *      - ESP_OK: Color set successfully.
+     *      - ESP_ERR_INVALID_ARG: Invalid LED index or other parameters.
+     *      - ESP_FAIL: Failed to update LED color.
+     */
+    esp_err_t bsp_setledcolor(int index, uint8_t red, uint8_t green, uint8_t blue);
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/bsp/esp32_c5_lcd_1_47/include/bsp/esp32_c5_lcd_1_47.h
+++ b/bsp/esp32_c5_lcd_1_47/include/bsp/esp32_c5_lcd_1_47.h
@@ -72,7 +72,7 @@
  *  @{
  */
 /* Display */
-#define BSP_LCD_CS   (GPIO_NUM_23) 
+#define BSP_LCD_CS   (GPIO_NUM_23)
 #define BSP_LCD_CLK  (GPIO_NUM_7)
 #define BSP_LCD_DATA (GPIO_NUM_6)
 #define BSP_LCD_DC   (GPIO_NUM_24)

--- a/bsp/esp32_c5_lcd_1_47/include/bsp/touch.h
+++ b/bsp/esp32_c5_lcd_1_47/include/bsp/touch.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026-2027 Waveshare Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief BSP Touchscreen
+ *
+ * This file offers API for basic touchscreen initialization.
+ * It is useful for users who want to use the touchscreen without the default Graphical Library LVGL.
+ *
+ * For standard LCD initialization with LVGL graphical library, you can call all-in-one function bsp_display_start().
+ */
+
+#pragma once
+
+#include "esp_err.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \addtogroup g04_display
+ *  @{
+ */
+
+/**
+ * @brief BSP touch configuration structure
+ *
+ */
+typedef struct {
+    void *dummy;    /*!< Prepared for future use. */
+} bsp_touch_config_t;
+
+
+/** @} */ // end of display
+#ifdef __cplusplus
+}
+#endif

--- a/bsp/esp32_c5_lcd_1_47/priv_include/bsp_err_check.h
+++ b/bsp/esp32_c5_lcd_1_47/priv_include/bsp_err_check.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "esp_check.h"
+#include "sdkconfig.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Assert on error, if selected in menuconfig. Otherwise return error code. */
+#if CONFIG_BSP_ERROR_CHECK
+#define BSP_ERROR_CHECK_RETURN_ERR(x)    ESP_ERROR_CHECK(x)
+#define BSP_ERROR_CHECK_RETURN_NULL(x)   ESP_ERROR_CHECK(x)
+#define BSP_NULL_CHECK(x, ret)           assert(x)
+#define BSP_NULL_CHECK_GOTO(x, goto_tag) assert(x)
+#else
+#define BSP_ERROR_CHECK_RETURN_ERR(x) do { \
+        esp_err_t err_rc_ = (x);            \
+        if (unlikely(err_rc_ != ESP_OK)) {  \
+            return err_rc_;                 \
+        }                                   \
+    } while(0)
+
+#define BSP_ERROR_CHECK_RETURN_NULL(x)  do { \
+        if (unlikely((x) != ESP_OK)) {      \
+            return NULL;                    \
+        }                                   \
+    } while(0)
+
+#define BSP_NULL_CHECK(x, ret) do { \
+        if ((x) == NULL) {          \
+            return ret;             \
+        }                           \
+    } while(0)
+
+#define BSP_NULL_CHECK_GOTO(x, goto_tag) do { \
+        if ((x) == NULL) {      \
+            goto goto_tag;      \
+        }                       \
+    } while(0)
+#endif
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- Add a new `bsp/esp32_c5_lcd_1_47` Board Support Package for ESP32-C5-LCD-1.47.
- Add component metadata, CMake registration, Kconfig options, README, license, public BSP headers, and private error-check helpers.
- Add SPI LCD display support with ST7789 panel initialization, LVGL port integration, display rotation, locking, and brightness control.
- Add SPIFFS and SDSPI uSD card mount/unmount helpers.
- Add WS2812 LED strip support.
- Define board capabilities and pin mappings for display, storage, and LED features.
- Set initial component version to `1.0.0` for target `esp32c5`.

## Component
- Path: `bsp/esp32_c5_lcd_1_47`
- Target: `esp32c5`
- Version: `1.0.0`

## Testing
- Not run yet.