### PR TITLE
fix: adjust CST offset for ESP32-S3 AMOLED 1.8

### DIFF
--- a/bsp/esp32_s3_touch_amoled_1_8/README.md
+++ b/bsp/esp32_s3_touch_amoled_1_8/README.md
@@ -4,7 +4,7 @@
 
 The ESP32-S3-Touch-AMOLED-1.8 is a 1.8-inch 368×448 capacitive touch development board designed by waveshare electronics.
 
-BSP v2.0.2 keeps the FT5x06 panel offset unchanged and applies the CO5300 0x16 X offset when CST816S touch is detected.
+BSP v2.0.3 keeps the FT5x06 panel offset unchanged and applies the CO5300 0x10 X offset when CST816S touch is detected.
 
 |                           HW version                            | BSP Version |
 |:---------------------------------------------------------------:| :---------: |

--- a/bsp/esp32_s3_touch_amoled_1_8/esp32_s3_touch_amoled_1_8.c
+++ b/bsp/esp32_s3_touch_amoled_1_8/esp32_s3_touch_amoled_1_8.c
@@ -24,7 +24,7 @@
 
 static const char *TAG = "ESP32-S3-Touch-AMOLED-1.8";
 
-#define BSP_LCD_CST816S_X_GAP (0x16)
+#define BSP_LCD_CST816S_X_GAP (0x10)
 
 static i2c_master_bus_handle_t i2c_handle = NULL; // I2C Handle
 static bool i2c_initialized = false;

--- a/bsp/esp32_s3_touch_amoled_1_8/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_1_8/idf_component.yml
@@ -26,4 +26,4 @@ tags:
 targets:
 - esp32s3
 url: https://www.waveshare.com/esp32-s3-touch-amoled-1.8.htm
-version: 2.0.2
+version: 2.0.3


### PR DESCRIPTION
Summary:
- Change the CST816S CO5300 X offset from 0x16 to 0x10 while leaving FT5x06 unchanged.
- Bump esp32_s3_touch_amoled_1_8 BSP version to 2.0.3.
- Update the BSP README version note.

Validation:
- Ran component manifest self-check.
- Built the generated minimal esp32_s3_touch_amoled_1_8 component project with ESP-IDF v5.5.4 for esp32s3.