### PR TITLE
fix(bsp): update esp lvgl adapter dependency

### DIFF
--- a/bsp/esp32_p4_platform/idf_component.yml
+++ b/bsp/esp32_p4_platform/idf_component.yml
@@ -5,7 +5,7 @@ dependencies:
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
     public: true
-    version: "^0.5.1"
+    version: "~0.6"
   idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
   usb:
@@ -28,4 +28,4 @@ tags:
 targets:
 - esp32p4
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 2.0.0
+version: 2.0.1

--- a/bsp/esp32_p4_wifi6_touch_lcd_x/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_x/idf_component.yml
@@ -5,7 +5,7 @@ dependencies:
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
     public: true
-    version: "^0.5.1"
+    version: "~0.6"
   idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
   usb:
@@ -22,4 +22,4 @@ tags:
 targets:
 - esp32p4
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 2.0.0
+version: 2.0.1

--- a/bsp/esp32_p4_wifi6_touch_lcd_xc/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_xc/idf_component.yml
@@ -6,7 +6,7 @@ dependencies:
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
     public: true
-    version: "^0.5.1"
+    version: "~0.6"
   idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
   usb:
@@ -22,4 +22,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-3.4c.htm
-version: 3.0.0
+version: 3.0.1

--- a/bsp/esp32_s3_cam_ovxxxx/idf_component.yml
+++ b/bsp/esp32_s3_cam_ovxxxx/idf_component.yml
@@ -1,4 +1,4 @@
-version: 2.0.0
+version: 2.0.1
 description: Board Support Package (BSP) for Waveshare ESP32-S3-CAM-OVxxxx
 url: https://www.waveshare.com/esp32-s3-cam-ovxxxx.htm
 
@@ -17,7 +17,7 @@ dependencies:
   idf: ">=5.3"
   lvgl/lvgl: ">=8,<10"
   espressif/esp_lvgl_adapter:
-    version: "^0.1.*"
+    version: "~0.6"
     public: true
   espressif/esp_lcd_touch_cst816s: ^1.1.0
   esp_codec_dev:

--- a/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
+++ b/bsp/esp32_s3_lr1121_oled_1_54/idf_component.yml
@@ -2,7 +2,9 @@ dependencies:
   esp_codec_dev:
     public: true
     version: "~1.5"
-  espressif/esp_lvgl_adapter: "*"
+  espressif/esp_lvgl_adapter:
+    public: true
+    version: "~0.6"
   espressif/i2c_bus:
     public: true
     version: 1.4.*
@@ -26,4 +28,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 2.0.1
+version: 2.0.2

--- a/bsp/esp32_s3_touch_amoled_1_75/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_1_75/idf_component.yml
@@ -1,4 +1,4 @@
-version: 3.0.0
+version: 3.0.1
 description: Board Support Package (BSP) for Waveshare ESP32-S3-Touch-AMOLED-1.75
 url: https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm
 
@@ -19,7 +19,7 @@ dependencies:
   esp_lcd_co5300: "*"
   waveshare/esp_lcd_touch_cst9217: "*"
   espressif/esp_lvgl_adapter:
-    version: "^0.1.*"
+    version: "~0.6"
     public: true
 
   esp_codec_dev:

--- a/bsp/esp32_s3_touch_amoled_2_16/idf_component.yml
+++ b/bsp/esp32_s3_touch_amoled_2_16/idf_component.yml
@@ -11,7 +11,7 @@ dependencies:
   waveshare/esp_lcd_touch_cst9217: "*"
   espressif/esp_lvgl_adapter:
     public: true
-    version: "0.1.*"
+    version: "~0.6"
   idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
   esp_lcd_panel_io_additions: "^1"
@@ -21,4 +21,4 @@ tags:
 targets:
 - esp32s3
 url: https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm
-version: 2.0.0
+version: 2.0.1

--- a/bsp/esp32_s3_touch_lcd_4_3c/idf_component.yml
+++ b/bsp/esp32_s3_touch_lcd_4_3c/idf_component.yml
@@ -4,7 +4,7 @@ dependencies:
     version: "~1.5"
   esp_lcd_touch_gt911: '*'
   espressif/esp_lvgl_adapter:
-    version: "*"
+    version: "~0.6"
     public: true
   idf: '>=5.3'
   lvgl/lvgl: ~9.4.*
@@ -24,4 +24,4 @@ tags:
 targets:
 - esp32s3
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 3.0.0
+version: 3.0.1


### PR DESCRIPTION
## Summary
- Update BSP manifests that use `espressif/esp_lvgl_adapter` to the `~0.6` release line.
- Bump the affected BSP component patch versions.
- Keep the adapter dependency public where BSP headers expose adapter types.

## Notes
- The Espressif component registry currently resolves the `~0.6` line to `0.6.1`.
- Espressif's 0.6.1 examples still use the same `esp_lv_adapter_*` API family used by these BSPs.

## Validation
- `git diff --check`
- `python .github/scripts/component_self_check.py`