### PR TITLE
refactor(bsp): migrate P4 displays to LVGL adapter

### DIFF
--- a/bsp/esp32_p4_nano/Kconfig
+++ b/bsp/esp32_p4_nano/Kconfig
@@ -79,29 +79,11 @@ menu "Board Support Package(ESP32-P4)"
     menu "Display"
         config BSP_LCD_DPI_BUFFER_NUMS
             int "Set number of frame buffers"
-            default 1
+            default 3
             range 1 3
             help
                 Let DPI LCD driver create a specified number of frame-size buffers.
                 Only when it is set to multiple can the avoiding tearing be turned on.
-
-        config BSP_DISPLAY_LVGL_AVOID_TEAR
-            bool "Avoid tearing effect"
-            depends on BSP_LCD_DPI_BUFFER_NUMS > 1
-            default "n"
-            help
-                Avoid tearing effect through LVGL buffer mode and double frame buffers
-                of RGB LCD. This feature is only available for RGB LCD.
-
-        choice BSP_DISPLAY_LVGL_MODE
-            depends on BSP_DISPLAY_LVGL_AVOID_TEAR
-            prompt "Select LVGL buffer mode"
-            default BSP_DISPLAY_LVGL_FULL_REFRESH
-            config BSP_DISPLAY_LVGL_FULL_REFRESH
-                bool "Full refresh"
-            config BSP_DISPLAY_LVGL_DIRECT_MODE
-                bool "Direct mode"
-        endchoice
 
         config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
             int "LEDC channel index"

--- a/bsp/esp32_p4_nano/README.md
+++ b/bsp/esp32_p4_nano/README.md
@@ -111,7 +111,7 @@ bsp_display_brightness_set(100);
 |   DISPLAY   |:heavy_check_mark:| [waveshare/esp_lcd_ili9881c](https://components.espressif.com/components/waveshare/esp_lcd_ili9881c)     | 1.0.1   |
 |   DISPLAY   |:heavy_check_mark:| [waveshare/esp_lcd_hx8394](https://components.espressif.com/components/waveshare/esp_lcd_hx8394)       | 1.0.2   |
 |   DISPLAY   |:heavy_check_mark:| [waveshare/esp_lcd_dsi](https://components.espressif.com/components/waveshare/esp_lcd_dsi)               | 1.0.3   |
-|  LVGL_PORT  |:heavy_check_mark:| [espressif/esp_lvgl_port](https://components.espressif.com/components/espressif/esp_lvgl_port)           | ^2      |
+| LVGL_ADAPTER|:heavy_check_mark:| [espressif/esp_lvgl_adapter](https://components.espressif.com/components/espressif/esp_lvgl_adapter)     | ~0.6    |
 |    TOUCH    |:heavy_check_mark:| [espressif/esp_lcd_touch_gt911](https://components.espressif.com/components/espressif/esp_lcd_touch_gt911) | ^1      |
 |   BUTTONS   |        :x:       |                                                                                                          |         |
 |    AUDIO    |:heavy_check_mark:| [espressif/esp_codec_dev](https://components.espressif.com/components/espressif/esp_codec_dev)           | 1.2.*   |

--- a/bsp/esp32_p4_nano/esp32_p4_nano.c
+++ b/bsp/esp32_p4_nano/esp32_p4_nano.c
@@ -666,24 +666,7 @@ esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t
 {
     ESP_RETURN_ON_ERROR(bsp_lcd_check_chip_revision(), TAG, "LCD chip revision check failed");
 
-    /* Initilize I2C */
-    BSP_ERROR_CHECK_RETURN_ERR(bsp_i2c_init());
-
-    /* Initialize touch */
-    const esp_lcd_touch_config_t tp_cfg = {
-#if CONFIG_BSP_LCD_TYPE_480_640_2_8_INCH || CONFIG_BSP_LCD_TYPE_480_800_4_INCH
-        .x_max = BSP_LCD_V_RES,
-        .y_max = BSP_LCD_H_RES,
-#else
-        .x_max = BSP_LCD_H_RES,
-        .y_max = BSP_LCD_V_RES,
-#endif
-        .rst_gpio_num = BSP_LCD_TOUCH_RST, // Shared with LCD reset
-        .int_gpio_num = BSP_LCD_TOUCH_INT,
-        .levels = {
-            .reset = 0,
-            .interrupt = 0,
-        },
+    const bsp_touch_config_t default_config = {
         .flags = {
 #if CONFIG_BSP_LCD_TYPE_800_1280_10_1_INCH || CONFIG_BSP_LCD_TYPE_800_1280_10_1_INCH_A || CONFIG_BSP_LCD_TYPE_720_1280_7_INCH_A || CONFIG_BSP_LCD_TYPE_720_1280_9_INCH_B || CONFIG_BSP_LCD_TYPE_720_1280_10_1_INCH_B
             .swap_xy = 0,
@@ -706,6 +689,34 @@ esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t
             .mirror_x = 0,
             .mirror_y = 0,
 #endif
+        },
+    };
+    if (config == NULL) {
+        config = &default_config;
+    }
+
+    /* Initilize I2C */
+    BSP_ERROR_CHECK_RETURN_ERR(bsp_i2c_init());
+
+    /* Initialize touch */
+    const esp_lcd_touch_config_t tp_cfg = {
+#if CONFIG_BSP_LCD_TYPE_480_640_2_8_INCH || CONFIG_BSP_LCD_TYPE_480_800_4_INCH
+        .x_max = BSP_LCD_V_RES,
+        .y_max = BSP_LCD_H_RES,
+#else
+        .x_max = BSP_LCD_H_RES,
+        .y_max = BSP_LCD_V_RES,
+#endif
+        .rst_gpio_num = BSP_LCD_TOUCH_RST, // Shared with LCD reset
+        .int_gpio_num = BSP_LCD_TOUCH_INT,
+        .levels = {
+            .reset = 0,
+            .interrupt = 0,
+        },
+        .flags = {
+            .swap_xy = config->flags.swap_xy,
+            .mirror_x = config->flags.mirror_x,
+            .mirror_y = config->flags.mirror_y,
         },
     };
     esp_lcd_panel_io_handle_t tp_io_handle = NULL;
@@ -736,106 +747,92 @@ static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
 
     /* Add LCD screen */
     ESP_LOGD(TAG, "Add LCD screen");
-    const lvgl_port_display_cfg_t disp_cfg = {
-        .io_handle = lcd_panels.io,
-        .panel_handle = lcd_panels.panel,
-        .control_handle = lcd_panels.control,
-        .buffer_size = cfg->buffer_size,
-        .double_buffer = cfg->double_buffer,
-        .hres = BSP_LCD_H_RES,
-        .vres = BSP_LCD_V_RES,
-        .monochrome = false,
-        /* Rotation values must be same as used in esp_lcd for initial settings of the screen */
-        .rotation = {
-            .swap_xy = false,
-            .mirror_x = true,
-            .mirror_y = true,
+    const esp_lv_adapter_display_config_t disp_cfg = {
+        .panel = lcd_panels.panel,
+        .panel_io = lcd_panels.io,
+        .profile = {
+            .interface = ESP_LV_ADAPTER_PANEL_IF_MIPI_DSI,
+            .rotation = cfg->rotation,
+            .hor_res = BSP_LCD_H_RES,
+            .ver_res = BSP_LCD_V_RES,
+            .buffer_height = 50,
+            .use_psram = false,
+            .enable_ppa_accel = false,
+            .require_double_buffer = false,
         },
-#if LVGL_VERSION_MAJOR >= 9
-#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
-        .color_format = LV_COLOR_FORMAT_RGB888,
-#else
-        .color_format = LV_COLOR_FORMAT_RGB565,
-#endif
-#endif
-        .flags = {
-            .buff_dma = cfg->flags.buff_dma,
-            .buff_spiram = cfg->flags.buff_spiram,
-#if LVGL_VERSION_MAJOR >= 9
-            .swap_bytes = (BSP_LCD_BIGENDIAN ? true : false),
-#endif
-#if CONFIG_BSP_DISPLAY_LVGL_AVOID_TEAR
-            .sw_rotate = false,                /* Avoid tearing is not supported for SW rotation */
-#else
-            .sw_rotate = cfg->flags.sw_rotate, /* Only SW rotation is supported for 90° and 270° */
-#endif
-#if CONFIG_BSP_DISPLAY_LVGL_FULL_REFRESH
-            .full_refresh = true,
-#elif CONFIG_BSP_DISPLAY_LVGL_DIRECT_MODE
-            .direct_mode = true,
-#endif
-        }
+        .tear_avoid_mode = cfg->tear_avoid_mode,
     };
 
-    const lvgl_port_display_dsi_cfg_t dpi_cfg = {
-        .flags = {
-#if CONFIG_BSP_DISPLAY_LVGL_AVOID_TEAR
-            .avoid_tearing = true,
-#else
-            .avoid_tearing = false,
-#endif
-        }
-    };
-
-    return lvgl_port_add_disp_dsi(&disp_cfg, &dpi_cfg);
+    return esp_lv_adapter_register_display(&disp_cfg);
 }
 
-static lv_indev_t *bsp_display_indev_init(lv_display_t *disp)
+static lv_indev_t *bsp_display_indev_init(const bsp_display_cfg_t *cfg, lv_display_t *disp)
 {
+    assert(cfg != NULL);
     esp_lcd_touch_handle_t tp;
-    BSP_ERROR_CHECK_RETURN_NULL(bsp_touch_new(NULL, &tp));
+    const bsp_touch_config_t touch_config = {
+        .flags = {
+            .swap_xy = cfg->touch_flags.swap_xy,
+            .mirror_x = cfg->touch_flags.mirror_x,
+            .mirror_y = cfg->touch_flags.mirror_y,
+        },
+    };
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_touch_new(&touch_config, &tp));
     assert(tp);
 
     /* Add touch input (for selected screen) */
-    const lvgl_port_touch_cfg_t touch_cfg = {
-        .disp = disp,
-        .handle = tp,
-    };
+    const esp_lv_adapter_touch_config_t touch_cfg = ESP_LV_ADAPTER_TOUCH_DEFAULT_CONFIG(disp, tp);
 
-    return lvgl_port_add_touch(&touch_cfg);
+    return esp_lv_adapter_register_touch(&touch_cfg);
 }
 
 lv_display_t *bsp_display_start(void)
 {
     bsp_display_cfg_t cfg = {
-        .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG(),
-        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
-        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
-        .flags = {
-#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
-            .buff_dma = false,
+        .lv_adapter_cfg = ESP_LV_ADAPTER_DEFAULT_CONFIG(),
+        .rotation = ESP_LV_ADAPTER_ROTATE_180,
+        .tear_avoid_mode = ESP_LV_ADAPTER_TEAR_AVOID_MODE_TRIPLE_PARTIAL,
+        .touch_flags = {
+#if CONFIG_BSP_LCD_TYPE_800_1280_10_1_INCH || CONFIG_BSP_LCD_TYPE_800_1280_10_1_INCH_A || CONFIG_BSP_LCD_TYPE_720_1280_7_INCH_A || CONFIG_BSP_LCD_TYPE_720_1280_9_INCH_B || CONFIG_BSP_LCD_TYPE_720_1280_10_1_INCH_B
+            .swap_xy = 0,
+            .mirror_x = 1,
+            .mirror_y = 1,
+#elif CONFIG_BSP_LCD_TYPE_800_1280_8_INCH_A
+            .swap_xy = 0,
+            .mirror_x = 0,
+            .mirror_y = 0,
+#elif CONFIG_BSP_LCD_TYPE_480_640_2_8_INCH
+            .swap_xy = 1,
+            .mirror_x = 0,
+            .mirror_y = 1,
+#elif CONFIG_BSP_LCD_TYPE_480_800_4_INCH
+            .swap_xy = 1,
+            .mirror_x = 1,
+            .mirror_y = 0,
 #else
-            .buff_dma = true,
+            .swap_xy = 0,
+            .mirror_x = 0,
+            .mirror_y = 0,
 #endif
-            .buff_spiram = false,
-            .sw_rotate = true,
-        }
+        },
     };
     return bsp_display_start_with_config(&cfg);
 }
 
-lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
+lv_display_t *bsp_display_start_with_config(bsp_display_cfg_t *cfg)
 {
     lv_display_t *disp;
 
     assert(cfg != NULL);
-    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
+    BSP_ERROR_CHECK_RETURN_NULL(esp_lv_adapter_init(&cfg->lv_adapter_cfg));
 
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
 
     BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
 
-    BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
+    BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(cfg, disp), NULL);
+
+    ESP_ERROR_CHECK(esp_lv_adapter_start());
 
     return disp;
 }
@@ -852,12 +849,12 @@ void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
 
 bool bsp_display_lock(uint32_t timeout_ms)
 {
-    return lvgl_port_lock(timeout_ms);
+    return esp_lv_adapter_lock(timeout_ms) == ESP_OK;
 }
 
 void bsp_display_unlock(void)
 {
-    lvgl_port_unlock();
+    esp_lv_adapter_unlock();
 }
 
 #endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)

--- a/bsp/esp32_p4_nano/esp32_p4_nano.c
+++ b/bsp/esp32_p4_nano/esp32_p4_nano.c
@@ -847,7 +847,7 @@ void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
     lv_disp_set_rotation(disp, rotation);
 }
 
-bool bsp_display_lock(uint32_t timeout_ms)
+bool bsp_display_lock(int32_t timeout_ms)
 {
     return esp_lv_adapter_lock(timeout_ms) == ESP_OK;
 }

--- a/bsp/esp32_p4_nano/idf_component.yml
+++ b/bsp/esp32_p4_nano/idf_component.yml
@@ -3,10 +3,10 @@ dependencies:
     public: true
     version: "~1.5"
   esp_lcd_touch_gt911: ^1
-  espressif/esp_lvgl_port:
+  espressif/esp_lvgl_adapter:
     public: true
-    version: ^2
-  idf: '>=5.3'
+    version: "~0.6"
+  idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
   usb:
     version: "^1.0.0"
@@ -30,4 +30,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-nano.htm
-version: 2.0.0
+version: 3.0.0

--- a/bsp/esp32_p4_nano/include/bsp/esp32_p4_nano.h
+++ b/bsp/esp32_p4_nano/include/bsp/esp32_p4_nano.h
@@ -292,11 +292,11 @@ lv_indev_t *bsp_display_get_input_dev(void);
 /**
  * @brief Take LVGL mutex
  *
- * @param timeout_ms Timeout in [ms]. 0 will block indefinitely.
+ * @param timeout_ms Timeout in [ms]. -1 will block indefinitely.
  * @return true  Mutex was taken
  * @return false Mutex was NOT taken
  */
-bool bsp_display_lock(uint32_t timeout_ms);
+bool bsp_display_lock(int32_t timeout_ms);
 
 /**
  * @brief Give LVGL mutex

--- a/bsp/esp32_p4_nano/include/bsp/esp32_p4_nano.h
+++ b/bsp/esp32_p4_nano/include/bsp/esp32_p4_nano.h
@@ -12,7 +12,7 @@
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 #include "lvgl.h"
-#include "esp_lvgl_port.h"
+#include "esp_lv_adapter.h"
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /**************************************************************************************************
@@ -243,22 +243,19 @@ esp_err_t bsp_sdcard_unmount(void);
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
-#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 50) // Frame buffer size in pixels
-#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
-
 /**
  * @brief BSP display configuration structure
  *
  */
 typedef struct {
-    lvgl_port_cfg_t lvgl_port_cfg;  /*!< LVGL port configuration */
-    uint32_t        buffer_size;    /*!< Size of the buffer for the screen in pixels */
-    bool            double_buffer;  /*!< True, if should be allocated two buffers */
+    esp_lv_adapter_config_t          lv_adapter_cfg;   /*!< LVGL adapter configuration */
+    esp_lv_adapter_rotation_t        rotation;         /*!< Display rotation */
+    esp_lv_adapter_tear_avoid_mode_t tear_avoid_mode;  /*!< Tearing avoidance mode */
     struct {
-        unsigned int buff_dma: 1;    /*!< Allocated LVGL buffer will be DMA capable */
-        unsigned int buff_spiram: 1; /*!< Allocated LVGL buffer will be in PSRAM */
-        unsigned int sw_rotate: 1;   /*!< Use software rotation (slower), The feature is unavailable under avoid-tear mode */
-    } flags;
+        unsigned int swap_xy: 1;   /*!< Swap X and Y after reading touch coordinates */
+        unsigned int mirror_x: 1;  /*!< Mirror X after reading touch coordinates */
+        unsigned int mirror_y: 1;  /*!< Mirror Y after reading touch coordinates */
+    } touch_flags;
 } bsp_display_cfg_t;
 
 /**
@@ -281,7 +278,7 @@ lv_display_t *bsp_display_start(void);
  *
  * @return Pointer to LVGL display or NULL when error occured
  */
-lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg);
+lv_display_t *bsp_display_start_with_config(bsp_display_cfg_t *cfg);
 
 /**
  * @brief Get pointer to input device (touch, buttons, ...)

--- a/bsp/esp32_p4_nano/include/bsp/touch.h
+++ b/bsp/esp32_p4_nano/include/bsp/touch.h
@@ -10,7 +10,11 @@ extern "C" {
  *
  */
 typedef struct {
-    void *dummy;    /*!< Prepared for future use. */
+    struct {
+        unsigned int swap_xy: 1;   /*!< Swap X and Y after reading coordinates */
+        unsigned int mirror_x: 1;  /*!< Mirror X after reading coordinates */
+        unsigned int mirror_y: 1;  /*!< Mirror Y after reading coordinates */
+    } flags;
 } bsp_touch_config_t;
 
 /**

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/Kconfig
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/Kconfig
@@ -79,28 +79,11 @@ menu "Board Support Package(ESP32-P4)"
     menu "Display"
         config BSP_LCD_DPI_BUFFER_NUMS
             int "Set number of frame buffers"
-            default 1
+            default 3
             range 1 3
             help
                 Let DPI LCD driver create a specified number of frame-size buffers. Only when it is set to multiple can the avoiding tearing be turned on.
 
-        config BSP_DISPLAY_LVGL_AVOID_TEAR
-            bool "Avoid tearing effect"
-            depends on BSP_LCD_DPI_BUFFER_NUMS > 1
-            default "n"
-            help
-                Avoid tearing effect through LVGL buffer mode and double frame buffers of RGB LCD. This feature is only available for RGB LCD.
-
-        choice BSP_DISPLAY_LVGL_MODE
-            depends on BSP_DISPLAY_LVGL_AVOID_TEAR
-            prompt "Select LVGL buffer mode"
-            default BSP_DISPLAY_LVGL_FULL_REFRESH
-            config BSP_DISPLAY_LVGL_FULL_REFRESH
-                bool "Full refresh"
-            config BSP_DISPLAY_LVGL_DIRECT_MODE
-                bool "Direct mode"
-        endchoice
-            
         config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
         int "LEDC channel index"
         default 1

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/README.md
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/README.md
@@ -24,7 +24,7 @@ bsp_display_brightness_set(100);
 |  Capability |     Available    | Component                                                                                                  | Version |
 |-------------|------------------|------------------------------------------------------------------------------------------------------------|---------|
 |   DISPLAY   |:heavy_check_mark:| [waveshare/esp_lcd_st7703](https://components.espressif.com/components/waveshare/esp_lcd_st7703)           | 1.0.1   |
-|  LVGL_PORT  |:heavy_check_mark:| [espressif/esp_lvgl_port](https://components.espressif.com/components/espressif/esp_lvgl_port)             | ^2      |
+| LVGL_ADAPTER|:heavy_check_mark:| [espressif/esp_lvgl_adapter](https://components.espressif.com/components/espressif/esp_lvgl_adapter)       | ~0.6    |
 |    TOUCH    |:heavy_check_mark:| [espressif/esp_lcd_touch_gt911](https://components.espressif.com/components/espressif/esp_lcd_touch_gt911) | ^1      |
 |   BUTTONS   |        :x:       |                                                                                                            |         |
 |    AUDIO    |:heavy_check_mark:| [espressif/esp_codec_dev](https://components.espressif.com/components/espressif/esp_codec_dev)             | 1.2.*   |

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/esp32_p4_wifi6_touch_lcd_4b.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/esp32_p4_wifi6_touch_lcd_4b.c
@@ -415,7 +415,7 @@ esp_err_t bsp_audio_init_voice_24k(void)
     tx_config.gpio_cfg.din = I2S_GPIO_UNUSED;
     rx_config.clk_cfg.mclk_multiple = I2S_MCLK_MULTIPLE_256;
     rx_config.clk_cfg.bclk_div = 8;
-    rx_config.slot_cfg.total_slot = 4;
+    rx_config.slot_cfg.total_slot = BSP_AUDIO_TDM_SLOT_COUNT;
     rx_config.gpio_cfg.dout = I2S_GPIO_UNUSED;
 
     return bsp_audio_init_tx_std_rx_tdm(&tx_config, &rx_config);
@@ -510,7 +510,7 @@ esp_codec_dev_handle_t bsp_audio_codec_microphone_init(void)
     es7210_codec_cfg_t es7210_cfg = {
         .ctrl_if = microphone_ctrl_if,
         .mic_selected = (audio_mode == BSP_AUDIO_MODE_TX_STD_RX_TDM) ?
-                        (ES7210_SEL_MIC1 | ES7210_SEL_MIC2 | ES7210_SEL_MIC3 | ES7210_SEL_MIC4) : 0,
+                        BSP_AUDIO_ES7210_CONNECTED_MIC_MASK : 0,
     };
     microphone_codec_if = es7210_codec_new(&es7210_cfg);
     if (microphone_codec_if == NULL) {

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/esp32_p4_wifi6_touch_lcd_4b.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/esp32_p4_wifi6_touch_lcd_4b.c
@@ -613,7 +613,7 @@ void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
     lv_disp_set_rotation(disp, rotation);
 }
 
-bool bsp_display_lock(uint32_t timeout_ms)
+bool bsp_display_lock(int32_t timeout_ms)
 {
     return esp_lv_adapter_lock(timeout_ms) == ESP_OK;
 }

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/esp32_p4_wifi6_touch_lcd_4b.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/esp32_p4_wifi6_touch_lcd_4b.c
@@ -480,6 +480,17 @@ err:
 
 esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t *ret_touch)
 {
+    const bsp_touch_config_t default_config = {
+        .flags = {
+            .swap_xy = 0,
+            .mirror_x = 0,
+            .mirror_y = 0,
+        },
+    };
+    if (config == NULL) {
+        config = &default_config;
+    }
+
     /* Initilize I2C */
     BSP_ERROR_CHECK_RETURN_ERR(bsp_i2c_init());
 
@@ -499,9 +510,9 @@ esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t
             .interrupt = 0,
         },
         .flags = {
-            .swap_xy = 0,
-            .mirror_x = 0,
-            .mirror_y = 0,
+            .swap_xy = config->flags.swap_xy,
+            .mirror_x = config->flags.mirror_x,
+            .mirror_y = config->flags.mirror_y,
         },
     };
     esp_lcd_panel_io_handle_t tp_io_handle = NULL;
@@ -520,106 +531,74 @@ static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
 
     /* Add LCD screen */
     ESP_LOGD(TAG, "Add LCD screen");
-    const lvgl_port_display_cfg_t disp_cfg = {
-        .io_handle = lcd_panels.io,
-        .panel_handle = lcd_panels.panel,
-        .control_handle = lcd_panels.control,
-        .buffer_size = cfg->buffer_size,
-        .double_buffer = cfg->double_buffer,
-        .hres = BSP_LCD_H_RES,
-        .vres = BSP_LCD_V_RES,
-        .monochrome = false,
-        /* Rotation values must be same as used in esp_lcd for initial settings of the screen */
-        .rotation = {
-            .swap_xy = false,
-            .mirror_x = false,
-            .mirror_y = false,
+    const esp_lv_adapter_display_config_t disp_cfg = {
+        .panel = lcd_panels.panel,
+        .panel_io = lcd_panels.io,
+        .profile = {
+            .interface = ESP_LV_ADAPTER_PANEL_IF_MIPI_DSI,
+            .rotation = cfg->rotation,
+            .hor_res = BSP_LCD_H_RES,
+            .ver_res = BSP_LCD_V_RES,
+            .buffer_height = 50,
+            .use_psram = false,
+            .enable_ppa_accel = false,
+            .require_double_buffer = false,
         },
-#if LVGL_VERSION_MAJOR >= 9
-#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
-        .color_format = LV_COLOR_FORMAT_RGB888,
-#else
-        .color_format = LV_COLOR_FORMAT_RGB565,
-#endif
-#endif
-        .flags = {
-            .buff_dma = cfg->flags.buff_dma,
-            .buff_spiram = cfg->flags.buff_spiram,
-#if LVGL_VERSION_MAJOR >= 9
-            .swap_bytes = (BSP_LCD_BIGENDIAN ? true : false),
-#endif
-#if CONFIG_BSP_DISPLAY_LVGL_AVOID_TEAR
-            .sw_rotate = false,                /* Avoid tearing is not supported for SW rotation */
-#else
-            .sw_rotate = cfg->flags.sw_rotate, /* Only SW rotation is supported for 90° and 270° */
-#endif
-#if CONFIG_BSP_DISPLAY_LVGL_FULL_REFRESH
-            .full_refresh = true,
-#elif CONFIG_BSP_DISPLAY_LVGL_DIRECT_MODE
-            .direct_mode = true,
-#endif
-        }
+        .tear_avoid_mode = cfg->tear_avoid_mode,
     };
 
-    const lvgl_port_display_dsi_cfg_t dpi_cfg = {
-        .flags = {
-#if CONFIG_BSP_DISPLAY_LVGL_AVOID_TEAR
-            .avoid_tearing = true,
-#else
-            .avoid_tearing = false,
-#endif
-        }
-    };
-
-    return lvgl_port_add_disp_dsi(&disp_cfg, &dpi_cfg);
+    return esp_lv_adapter_register_display(&disp_cfg);
 }
 
-static lv_indev_t *bsp_display_indev_init(lv_display_t *disp)
+static lv_indev_t *bsp_display_indev_init(const bsp_display_cfg_t *cfg, lv_display_t *disp)
 {
+    assert(cfg != NULL);
     esp_lcd_touch_handle_t tp;
-    BSP_ERROR_CHECK_RETURN_NULL(bsp_touch_new(NULL, &tp));
+    const bsp_touch_config_t touch_config = {
+        .flags = {
+            .swap_xy = cfg->touch_flags.swap_xy,
+            .mirror_x = cfg->touch_flags.mirror_x,
+            .mirror_y = cfg->touch_flags.mirror_y,
+        },
+    };
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_touch_new(&touch_config, &tp));
     assert(tp);
 
     /* Add touch input (for selected screen) */
-    const lvgl_port_touch_cfg_t touch_cfg = {
-        .disp = disp,
-        .handle = tp,
-    };
+    const esp_lv_adapter_touch_config_t touch_cfg = ESP_LV_ADAPTER_TOUCH_DEFAULT_CONFIG(disp, tp);
 
-    return lvgl_port_add_touch(&touch_cfg);
+    return esp_lv_adapter_register_touch(&touch_cfg);
 }
 
 lv_display_t *bsp_display_start(void)
 {
     bsp_display_cfg_t cfg = {
-        .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG(),
-        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
-        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
-        .flags = {
-#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
-            .buff_dma = false,
-#else
-            .buff_dma = true,
-#endif
-            .buff_spiram = false,
-            .sw_rotate = true,
-        }
+        .lv_adapter_cfg = ESP_LV_ADAPTER_DEFAULT_CONFIG(),
+        .rotation = ESP_LV_ADAPTER_ROTATE_0,
+        .tear_avoid_mode = ESP_LV_ADAPTER_TEAR_AVOID_MODE_TRIPLE_PARTIAL,
+        .touch_flags = {
+            .swap_xy = 0,
+            .mirror_x = 0,
+            .mirror_y = 0,
+        },
     };
     return bsp_display_start_with_config(&cfg);
 }
 
-lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
+lv_display_t *bsp_display_start_with_config(bsp_display_cfg_t *cfg)
 {
     lv_display_t *disp;
 
     assert(cfg != NULL);
-    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
+    BSP_ERROR_CHECK_RETURN_NULL(esp_lv_adapter_init(&cfg->lv_adapter_cfg));
 
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
 
     BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
 
-    BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
+    BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(cfg, disp), NULL);
+
+    ESP_ERROR_CHECK(esp_lv_adapter_start());
 
     return disp;
 }
@@ -636,12 +615,12 @@ void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
 
 bool bsp_display_lock(uint32_t timeout_ms)
 {
-    return lvgl_port_lock(timeout_ms);
+    return esp_lv_adapter_lock(timeout_ms) == ESP_OK;
 }
 
 void bsp_display_unlock(void)
 {
-    lvgl_port_unlock();
+    esp_lv_adapter_unlock();
 }
 
 #endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/esp32_p4_wifi6_touch_lcd_4b.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/esp32_p4_wifi6_touch_lcd_4b.c
@@ -31,12 +31,29 @@ static TaskHandle_t usb_host_task;  // USB Host Library task
 #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0))
 static i2c_master_bus_handle_t i2c_handle = NULL;  // I2C Handle
 #endif
+typedef enum {
+    BSP_AUDIO_MODE_NONE,
+    BSP_AUDIO_MODE_STD_STD,
+    BSP_AUDIO_MODE_TX_STD_RX_TDM,
+} bsp_audio_mode_t;
+
+static bsp_audio_mode_t audio_mode = BSP_AUDIO_MODE_NONE;
 static i2s_chan_handle_t i2s_tx_chan = NULL;
 static i2s_chan_handle_t i2s_rx_chan = NULL;
 static const audio_codec_data_if_t *i2s_data_if = NULL;  /* Codec data interface */
+
+static esp_codec_dev_handle_t speaker_codec_dev = NULL;
+static const audio_codec_gpio_if_t *speaker_gpio_if = NULL;
+static const audio_codec_ctrl_if_t *speaker_ctrl_if = NULL;
+static const audio_codec_if_t *speaker_codec_if = NULL;
+
+static esp_codec_dev_handle_t microphone_codec_dev = NULL;
+static const audio_codec_ctrl_if_t *microphone_ctrl_if = NULL;
+static const audio_codec_if_t *microphone_codec_if = NULL;
+
 #define BSP_ES7210_CODEC_ADDR  ES7210_CODEC_DEFAULT_ADDR
 
-/* Can be used for `i2s_std_gpio_config_t` and/or `i2s_std_config_t` initialization */
+/* Can be used for I2S STD and TDM GPIO configuration */
 #define BSP_I2S_GPIO_CFG       \
     {                          \
         .mclk = BSP_I2S_MCLK,  \
@@ -51,7 +68,7 @@ static const audio_codec_data_if_t *i2s_data_if = NULL;  /* Codec data interface
         },                     \
     }
 
-/* This configuration is used by default in `bsp_extra_audio_init()` */
+/* This configuration is used by default in bsp_audio_init() */
 #define BSP_I2S_DUPLEX_MONO_CFG(_sample_rate)                                                         \
     {                                                                                                 \
         .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(_sample_rate),                                          \
@@ -180,34 +197,151 @@ esp_err_t bsp_spiffs_unmount(void)
  * I2S Audio Function
  *
  **************************************************************************************************/
-esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config)
+static void bsp_audio_update_result(esp_err_t *result, esp_err_t error)
 {
-    esp_err_t ret = ESP_FAIL;
-    if (i2s_tx_chan && i2s_rx_chan) {
-        /* Audio was initialized before */
+    if ((*result == ESP_OK) && (error != ESP_OK)) {
+        *result = error;
+    }
+}
+
+static void bsp_audio_update_codec_result(esp_err_t *result, int codec_error)
+{
+    if ((*result == ESP_OK) && (codec_error != ESP_CODEC_DEV_OK)) {
+        *result = ESP_FAIL;
+    }
+}
+
+static bool bsp_audio_has_resources(void)
+{
+    return (audio_mode != BSP_AUDIO_MODE_NONE) ||
+           (i2s_tx_chan != NULL) ||
+           (i2s_rx_chan != NULL) ||
+           (i2s_data_if != NULL) ||
+           (speaker_codec_dev != NULL) ||
+           (speaker_gpio_if != NULL) ||
+           (speaker_ctrl_if != NULL) ||
+           (speaker_codec_if != NULL) ||
+           (microphone_codec_dev != NULL) ||
+           (microphone_ctrl_if != NULL) ||
+           (microphone_codec_if != NULL);
+}
+
+static esp_err_t bsp_audio_delete_speaker_codec(void)
+{
+    esp_err_t ret = ESP_OK;
+
+    if (speaker_codec_dev != NULL) {
+        bsp_audio_update_codec_result(&ret, esp_codec_dev_close(speaker_codec_dev));
+        esp_codec_dev_delete(speaker_codec_dev);
+        speaker_codec_dev = NULL;
+    }
+    if (speaker_codec_if != NULL) {
+        bsp_audio_update_codec_result(&ret, audio_codec_delete_codec_if(speaker_codec_if));
+        speaker_codec_if = NULL;
+    }
+    if (speaker_ctrl_if != NULL) {
+        bsp_audio_update_codec_result(&ret, audio_codec_delete_ctrl_if(speaker_ctrl_if));
+        speaker_ctrl_if = NULL;
+    }
+    if (speaker_gpio_if != NULL) {
+        bsp_audio_update_codec_result(&ret, audio_codec_delete_gpio_if(speaker_gpio_if));
+        speaker_gpio_if = NULL;
+    }
+
+    return ret;
+}
+
+static esp_err_t bsp_audio_delete_microphone_codec(void)
+{
+    esp_err_t ret = ESP_OK;
+
+    if (microphone_codec_dev != NULL) {
+        bsp_audio_update_codec_result(&ret, esp_codec_dev_close(microphone_codec_dev));
+        esp_codec_dev_delete(microphone_codec_dev);
+        microphone_codec_dev = NULL;
+    }
+    if (microphone_codec_if != NULL) {
+        bsp_audio_update_codec_result(&ret, audio_codec_delete_codec_if(microphone_codec_if));
+        microphone_codec_if = NULL;
+    }
+    if (microphone_ctrl_if != NULL) {
+        bsp_audio_update_codec_result(&ret, audio_codec_delete_ctrl_if(microphone_ctrl_if));
+        microphone_ctrl_if = NULL;
+    }
+
+    return ret;
+}
+
+static esp_err_t bsp_audio_delete_i2s_channel(i2s_chan_handle_t *channel)
+{
+    esp_err_t ret = ESP_OK;
+    esp_err_t err;
+
+    if (*channel == NULL) {
         return ESP_OK;
     }
 
-    /* Setup I2S peripheral */
+    err = i2s_channel_disable(*channel);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ret = err;
+    }
+
+    err = i2s_del_channel(*channel);
+    bsp_audio_update_result(&ret, err);
+    *channel = NULL;
+
+    return ret;
+}
+
+esp_err_t bsp_audio_deinit(void)
+{
+    esp_err_t ret = ESP_OK;
+
+    bsp_audio_update_result(&ret, bsp_audio_delete_microphone_codec());
+    bsp_audio_update_result(&ret, bsp_audio_delete_speaker_codec());
+
+    if (i2s_data_if != NULL) {
+        bsp_audio_update_codec_result(&ret, audio_codec_delete_data_if(i2s_data_if));
+        i2s_data_if = NULL;
+    }
+
+    bsp_audio_update_result(&ret, bsp_audio_delete_i2s_channel(&i2s_rx_chan));
+    bsp_audio_update_result(&ret, bsp_audio_delete_i2s_channel(&i2s_tx_chan));
+    audio_mode = BSP_AUDIO_MODE_NONE;
+
+    return ret;
+}
+
+static esp_err_t bsp_audio_init_channels(const i2s_std_config_t *tx_config,
+                                         const i2s_std_config_t *rx_std_config,
+                                         const i2s_tdm_config_t *rx_tdm_config,
+                                         bsp_audio_mode_t mode)
+{
+    esp_err_t ret = ESP_OK;
+    esp_err_t cleanup_ret;
+
+    if (bsp_audio_has_resources()) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(CONFIG_BSP_I2S_NUM, I2S_ROLE_MASTER);
-    chan_cfg.auto_clear = true; // Auto clear the legacy data in the DMA buffer
-    BSP_ERROR_CHECK_RETURN_ERR(i2s_new_channel(&chan_cfg, &i2s_tx_chan, &i2s_rx_chan));
+    chan_cfg.auto_clear = true;
 
-    /* Setup I2S channels */
-    const i2s_std_config_t std_cfg_default = BSP_I2S_DUPLEX_MONO_CFG(22050);
-    const i2s_std_config_t *p_i2s_cfg = &std_cfg_default;
-    if (i2s_config != NULL) {
-        p_i2s_cfg = i2s_config;
+    ESP_GOTO_ON_ERROR(i2s_new_channel(&chan_cfg, &i2s_tx_chan, &i2s_rx_chan),
+                      err, TAG, "I2S channel creation failed");
+    ESP_GOTO_ON_ERROR(i2s_channel_init_std_mode(i2s_tx_chan, tx_config),
+                      err, TAG, "I2S TX STD initialization failed");
+
+    if (rx_tdm_config != NULL) {
+        ESP_GOTO_ON_ERROR(i2s_channel_init_tdm_mode(i2s_rx_chan, rx_tdm_config),
+                          err, TAG, "I2S RX TDM initialization failed");
+    } else {
+        ESP_GOTO_ON_ERROR(i2s_channel_init_std_mode(i2s_rx_chan, rx_std_config),
+                          err, TAG, "I2S RX STD initialization failed");
     }
 
-    if (i2s_tx_chan != NULL) {
-        ESP_GOTO_ON_ERROR(i2s_channel_init_std_mode(i2s_tx_chan, p_i2s_cfg), err, TAG, "I2S channel initialization failed");
-        ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_tx_chan), err, TAG, "I2S enabling failed");
-    }
-    if (i2s_rx_chan != NULL) {
-        ESP_GOTO_ON_ERROR(i2s_channel_init_std_mode(i2s_rx_chan, p_i2s_cfg), err, TAG, "I2S channel initialization failed");
-        ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_rx_chan), err, TAG, "I2S enabling failed");
-    }
+    ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_tx_chan), err, TAG, "I2S TX enabling failed");
+    ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_rx_chan), err, TAG, "I2S RX enabling failed");
 
     audio_codec_i2s_cfg_t i2s_cfg = {
         .port = CONFIG_BSP_I2S_NUM,
@@ -215,49 +349,111 @@ esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config)
         .tx_handle = i2s_tx_chan,
     };
     i2s_data_if = audio_codec_new_i2s_data(&i2s_cfg);
-    BSP_NULL_CHECK_GOTO(i2s_data_if, err);
+    if (i2s_data_if == NULL) {
+        ret = ESP_ERR_NO_MEM;
+        goto err;
+    }
 
+    audio_mode = mode;
     return ESP_OK;
 
 err:
-    if (i2s_tx_chan) {
-        i2s_del_channel(i2s_tx_chan);
+    cleanup_ret = bsp_audio_deinit();
+    if (cleanup_ret != ESP_OK) {
+        ESP_LOGE(TAG, "Audio cleanup failed: %s", esp_err_to_name(cleanup_ret));
     }
-    if (i2s_rx_chan) {
-        i2s_del_channel(i2s_rx_chan);
+    return ret;
+}
+
+esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config)
+{
+    if ((audio_mode == BSP_AUDIO_MODE_STD_STD) &&
+            (i2s_tx_chan != NULL) && (i2s_rx_chan != NULL) && (i2s_data_if != NULL)) {
+        return ESP_OK;
+    }
+    if (bsp_audio_has_resources()) {
+        return ESP_ERR_INVALID_STATE;
     }
 
-    return ret;
+    const i2s_std_config_t std_cfg_default = BSP_I2S_DUPLEX_MONO_CFG(22050);
+    const i2s_std_config_t *std_config = (i2s_config != NULL) ? i2s_config : &std_cfg_default;
+
+    return bsp_audio_init_channels(std_config, std_config, NULL, BSP_AUDIO_MODE_STD_STD);
+}
+
+esp_err_t bsp_audio_init_tx_std_rx_tdm(const i2s_std_config_t *tx_config,
+                                       const i2s_tdm_config_t *rx_config)
+{
+    if (bsp_audio_has_resources()) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (tx_config == NULL || rx_config == NULL ||
+            tx_config->clk_cfg.sample_rate_hz != rx_config->clk_cfg.sample_rate_hz) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return bsp_audio_init_channels(tx_config, NULL, rx_config, BSP_AUDIO_MODE_TX_STD_RX_TDM);
+}
+
+esp_err_t bsp_audio_init_voice_24k(void)
+{
+    i2s_std_config_t tx_config = {
+        .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(24000),
+        .slot_cfg = I2S_STD_PHILIP_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO),
+        .gpio_cfg = BSP_I2S_GPIO_CFG,
+    };
+    i2s_tdm_config_t rx_config = {
+        .clk_cfg = I2S_TDM_CLK_DEFAULT_CONFIG(24000),
+        .slot_cfg = I2S_TDM_PHILIP_SLOT_DEFAULT_CONFIG(
+            I2S_DATA_BIT_WIDTH_16BIT,
+            I2S_SLOT_MODE_STEREO,
+            I2S_TDM_SLOT0 | I2S_TDM_SLOT1 | I2S_TDM_SLOT2 | I2S_TDM_SLOT3),
+        .gpio_cfg = BSP_I2S_GPIO_CFG,
+    };
+
+    tx_config.clk_cfg.mclk_multiple = I2S_MCLK_MULTIPLE_256;
+    tx_config.gpio_cfg.din = I2S_GPIO_UNUSED;
+    rx_config.clk_cfg.mclk_multiple = I2S_MCLK_MULTIPLE_256;
+    rx_config.clk_cfg.bclk_div = 8;
+    rx_config.slot_cfg.total_slot = 4;
+    rx_config.gpio_cfg.dout = I2S_GPIO_UNUSED;
+
+    return bsp_audio_init_tx_std_rx_tdm(&tx_config, &rx_config);
 }
 
 esp_codec_dev_handle_t bsp_audio_codec_speaker_init(void)
 {
+    if (speaker_codec_dev != NULL) {
+        return speaker_codec_dev;
+    }
+
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_i2c_init());
     if (i2s_data_if == NULL) {
-        /* Initilize I2C */
-        BSP_ERROR_CHECK_RETURN_NULL(bsp_i2c_init());
-        /* Configure I2S peripheral and Power Amplifier */
         BSP_ERROR_CHECK_RETURN_NULL(bsp_audio_init(NULL));
     }
-    assert(i2s_data_if);
 
-    const audio_codec_gpio_if_t *gpio_if = audio_codec_new_gpio();
+    speaker_gpio_if = audio_codec_new_gpio();
+    if (speaker_gpio_if == NULL) {
+        goto err;
+    }
 
     audio_codec_i2c_cfg_t i2c_cfg = {
         .port = BSP_I2C_NUM,
         .addr = ES8311_CODEC_DEFAULT_ADDR,
         .bus_handle = i2c_handle,
     };
-    const audio_codec_ctrl_if_t *i2c_ctrl_if = audio_codec_new_i2c_ctrl(&i2c_cfg);
-    BSP_NULL_CHECK(i2c_ctrl_if, NULL);
+    speaker_ctrl_if = audio_codec_new_i2c_ctrl(&i2c_cfg);
+    if (speaker_ctrl_if == NULL) {
+        goto err;
+    }
 
     esp_codec_dev_hw_gain_t gain = {
         .pa_voltage = 5.0,
         .codec_dac_voltage = 3.3,
     };
-
     es8311_codec_cfg_t es8311_cfg = {
-        .ctrl_if = i2c_ctrl_if,
-        .gpio_if = gpio_if,
+        .ctrl_if = speaker_ctrl_if,
+        .gpio_if = speaker_gpio_if,
         .codec_mode = ESP_CODEC_DEV_WORK_MODE_DAC,
         .pa_pin = BSP_POWER_AMP_IO,
         .pa_reverted = false,
@@ -268,47 +464,74 @@ esp_codec_dev_handle_t bsp_audio_codec_speaker_init(void)
         .invert_sclk = false,
         .hw_gain = gain,
     };
-    const audio_codec_if_t *es8311_dev = es8311_codec_new(&es8311_cfg);
-    BSP_NULL_CHECK(es8311_dev, NULL);
+    speaker_codec_if = es8311_codec_new(&es8311_cfg);
+    if (speaker_codec_if == NULL) {
+        goto err;
+    }
 
     esp_codec_dev_cfg_t codec_dev_cfg = {
         .dev_type = ESP_CODEC_DEV_TYPE_OUT,
-        .codec_if = es8311_dev,
+        .codec_if = speaker_codec_if,
         .data_if = i2s_data_if,
     };
-    return esp_codec_dev_new(&codec_dev_cfg);
+    speaker_codec_dev = esp_codec_dev_new(&codec_dev_cfg);
+    if (speaker_codec_dev == NULL) {
+        goto err;
+    }
+
+    return speaker_codec_dev;
+
+err:
+    bsp_audio_delete_speaker_codec();
+    return NULL;
 }
 
 esp_codec_dev_handle_t bsp_audio_codec_microphone_init(void)
 {
+    if (microphone_codec_dev != NULL) {
+        return microphone_codec_dev;
+    }
+
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_i2c_init());
     if (i2s_data_if == NULL) {
-        /* Initilize I2C */
-        BSP_ERROR_CHECK_RETURN_NULL(bsp_i2c_init());
-        /* Configure I2S peripheral and Power Amplifier */
         BSP_ERROR_CHECK_RETURN_NULL(bsp_audio_init(NULL));
     }
-    assert(i2s_data_if);
 
     audio_codec_i2c_cfg_t i2c_cfg = {
         .port = BSP_I2C_NUM,
         .addr = BSP_ES7210_CODEC_ADDR,
         .bus_handle = i2c_handle,
     };
-    const audio_codec_ctrl_if_t *i2c_ctrl_if = audio_codec_new_i2c_ctrl(&i2c_cfg);
-    BSP_NULL_CHECK(i2c_ctrl_if, NULL);
+    microphone_ctrl_if = audio_codec_new_i2c_ctrl(&i2c_cfg);
+    if (microphone_ctrl_if == NULL) {
+        goto err;
+    }
 
     es7210_codec_cfg_t es7210_cfg = {
-        .ctrl_if = i2c_ctrl_if,
+        .ctrl_if = microphone_ctrl_if,
+        .mic_selected = (audio_mode == BSP_AUDIO_MODE_TX_STD_RX_TDM) ?
+                        (ES7210_SEL_MIC1 | ES7210_SEL_MIC2 | ES7210_SEL_MIC3 | ES7210_SEL_MIC4) : 0,
     };
-    const audio_codec_if_t *es7210_dev = es7210_codec_new(&es7210_cfg);
-    BSP_NULL_CHECK(es7210_dev, NULL);
+    microphone_codec_if = es7210_codec_new(&es7210_cfg);
+    if (microphone_codec_if == NULL) {
+        goto err;
+    }
 
-    esp_codec_dev_cfg_t codec_es7210_dev_cfg = {
+    esp_codec_dev_cfg_t codec_dev_cfg = {
         .dev_type = ESP_CODEC_DEV_TYPE_IN,
-        .codec_if = es7210_dev,
+        .codec_if = microphone_codec_if,
         .data_if = i2s_data_if,
     };
-    return esp_codec_dev_new(&codec_es7210_dev_cfg);
+    microphone_codec_dev = esp_codec_dev_new(&codec_dev_cfg);
+    if (microphone_codec_dev == NULL) {
+        goto err;
+    }
+
+    return microphone_codec_dev;
+
+err:
+    bsp_audio_delete_microphone_codec();
+    return NULL;
 }
 
 // Bit number used to represent command and parameter

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/idf_component.yml
@@ -3,10 +3,10 @@ dependencies:
     public: true
     version: "~1.5"
   esp_lcd_touch_gt911: ^1
-  espressif/esp_lvgl_port:
+  espressif/esp_lvgl_adapter:
     public: true
-    version: ^2
-  idf: '>=5.4'
+    version: "~0.6"
+  idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
   usb:
     version: "^1.0.0"
@@ -21,4 +21,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-3.4c.htm
-version: 2.0.0
+version: 3.0.0

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
@@ -292,11 +292,11 @@ lv_indev_t *bsp_display_get_input_dev(void);
 /**
  * @brief Take LVGL mutex
  *
- * @param timeout_ms Timeout in [ms]. 0 will block indefinitely.
+ * @param timeout_ms Timeout in [ms]. -1 will block indefinitely.
  * @return true  Mutex was taken
  * @return false Mutex was NOT taken
  */
-bool bsp_display_lock(uint32_t timeout_ms);
+bool bsp_display_lock(int32_t timeout_ms);
 
 /**
  * @brief Give LVGL mutex

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
@@ -5,6 +5,7 @@
 #include "driver/i2c_master.h"
 #include "driver/sdmmc_host.h"
 #include "driver/i2s_std.h"
+#include "driver/i2s_tdm.h"
 #include "bsp/config.h"
 #include "bsp/display.h"
 #include "esp_codec_dev.h"
@@ -105,47 +106,102 @@ i2c_master_bus_handle_t bsp_i2c_get_handle(void);
  * I2S audio interface
  *
  * There are two devices connected to the I2S peripheral:
- *  - Codec ES8311 for output(playback) and input(recording) path
+ *  - Codec ES8311 for output (playback)
+ *  - ADC ES7210 for input (recording)
  *
- * For speaker initialization use bsp_audio_codec_speaker_init() which is inside initialize I2S with bsp_audio_init().
- * For microphone initialization use bsp_audio_codec_microphone_init() which is inside initialize I2S with bsp_audio_init().
- * After speaker or microphone initialization, use functions from esp_codec_dev for play/record audio.
- * Example audio play:
- * \code{.c}
- * esp_codec_dev_set_out_vol(spk_codec_dev, DEFAULT_VOLUME);
- * esp_codec_dev_open(spk_codec_dev, &fs);
- * esp_codec_dev_write(spk_codec_dev, wav_bytes, bytes_read_from_spiffs);
- * esp_codec_dev_close(spk_codec_dev);
- * \endcode
+ * Codec device handles returned by this BSP are BSP-owned. Applications may open and close them,
+ * but must not call esp_codec_dev_delete(). bsp_audio_deinit() closes and deletes the codec devices,
+ * their interfaces, the shared data interface, and the I2S channels.
  **************************************************************************************************/
 
 /**
- * @brief Init audio
+ * @brief Initialize legacy STD TX and STD RX audio
  *
- * @note There is no deinit audio function. Users can free audio resources by calling i2s_del_channel()
- * @warning The type of i2s_config param is depending on IDF version.
- * @param[in]  i2s_config I2S configuration. Pass NULL to use default values (Mono, duplex, 16bit, 22050 Hz)
+ * Repeated calls return ESP_OK only while the existing audio mode is STD TX and STD RX.
+ *
+ * @param[in] i2s_config I2S STD configuration. Pass NULL to use mono, duplex, 16-bit, 22050 Hz.
  * @return
  *      - ESP_OK                On success
  *      - ESP_ERR_NOT_SUPPORTED The communication mode is not supported on the current chip
- *      - ESP_ERR_INVALID_ARG   NULL pointer or invalid configuration
+ *      - ESP_ERR_INVALID_ARG   Invalid configuration
  *      - ESP_ERR_NOT_FOUND     No available I2S channel found
  *      - ESP_ERR_NO_MEM        No memory for storing the channel information
- *      - ESP_ERR_INVALID_STATE This channel has not initialized or already started
+ *      - ESP_ERR_INVALID_STATE Audio is already initialized in another mode
  */
 esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config);
 
 /**
- * @brief Initialize speaker codec device
+ * @brief Initialize audio with STD TX and TDM RX
  *
- * @return Pointer to codec device handle or NULL when error occurred
+ * TX and RX share the physical clock signals and must use the same sample rate. This function must
+ * be called before creating codec devices. It returns ESP_ERR_INVALID_STATE if any audio mode is
+ * already initialized, including an earlier mixed-mode initialization.
+ *
+ * @param[in] tx_config Non-NULL I2S STD configuration for playback
+ * @param[in] rx_config Non-NULL I2S TDM configuration for recording
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   NULL configuration or mismatched TX/RX sample rates
+ *      - ESP_ERR_INVALID_STATE Audio is already initialized
+ *      - other errors from the I2S driver
+ */
+esp_err_t bsp_audio_init_tx_std_rx_tdm(const i2s_std_config_t *tx_config,
+                                       const i2s_tdm_config_t *rx_config);
+
+/**
+ * @brief Initialize the 24 kHz voice audio bus profile
+ *
+ * The physical bus uses 24 kHz, 16-bit stereo STD for TX and 24 kHz, 16-bit TDM slots 0..3 for RX.
+ * RX uses four total slots, BCLK divider 8, and MCLK x256. The ES7210 codec interface enables MIC1
+ * through MIC4 so esp_codec_dev can retain the four-channel TDM frame.
+ *
+ * @note This configures the physical bus only. It does not select a record channel mask and does not
+ *       imply AEC or a reference channel. For single-microphone capture, open the record codec with
+ *       channel=4 and channel_mask=ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0), then set gain for that mask.
+ *       Callers may choose another channel mask when their capture topology requires it.
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_STATE Audio is already initialized
+ *      - other errors from bsp_audio_init_tx_std_rx_tdm()
+ */
+esp_err_t bsp_audio_init_voice_24k(void);
+
+/**
+ * @brief Deinitialize BSP-owned audio resources
+ *
+ * This function closes and deletes codec devices created by bsp_audio_codec_speaker_init() and
+ * bsp_audio_codec_microphone_init(), deletes their interfaces and the shared data interface,
+ * disables and deletes RX/TX channels, and clears all internal audio pointers.
+ *
+ * @warning Stop all tasks using the codec handles and close the devices before calling this function.
+ *          All codec handles returned by the BSP become invalid after this call.
+ * @note The shared I2C bus is not deinitialized.
+ *
+ * @return
+ *      - ESP_OK On success or when audio is already deinitialized
+ *      - ESP_FAIL If a codec interface could not be closed or deleted
+ *      - other errors from the I2S driver
+ */
+esp_err_t bsp_audio_deinit(void);
+
+/**
+ * @brief Initialize or get the BSP-owned speaker codec device
+ *
+ * If audio is not initialized, this function initializes the legacy STD/STD mode.
+ *
+ * @return BSP-owned codec device handle, or NULL when an error occurs
  */
 esp_codec_dev_handle_t bsp_audio_codec_speaker_init(void);
 
 /**
- * @brief Initialize microphone codec device
+ * @brief Initialize or get the BSP-owned microphone codec device
  *
- * @return Pointer to codec device handle or NULL when error occurred
+ * If audio is not initialized, this function initializes the legacy STD/STD mode. In mixed
+ * STD TX/TDM RX mode, the ES7210 enables MIC1 through MIC4; esp_codec_dev_open() still controls
+ * which packed TDM channels are returned through its channel_mask.
+ *
+ * @return BSP-owned codec device handle, or NULL when an error occurs
  */
 esp_codec_dev_handle_t bsp_audio_codec_microphone_init(void);
 

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
@@ -101,6 +101,34 @@ esp_err_t bsp_i2c_deinit(void);
  */
 i2c_master_bus_handle_t bsp_i2c_get_handle(void);
 
+/*
+ * ES7210 physical microphone masks for mic_selected and esp_codec_dev_set_in_channel_gain().
+ * Board labels from MSB to LSB are MIC4=NA, MIC3=RE, MIC2=FR, and MIC1=FL.
+ * These masks address physical MIC inputs, not serialized TDM slots.
+ */
+#define BSP_AUDIO_ES7210_MIC1_FL_MASK          (1U << 0)
+#define BSP_AUDIO_ES7210_MIC2_FR_MASK          (1U << 1)
+#define BSP_AUDIO_ES7210_MIC3_RE_MASK          (1U << 2)
+#define BSP_AUDIO_ES7210_MIC4_NA_MASK          (1U << 3)
+#define BSP_AUDIO_ES7210_MIC_MASK_FL_FR        (BSP_AUDIO_ES7210_MIC1_FL_MASK | BSP_AUDIO_ES7210_MIC2_FR_MASK)
+#define BSP_AUDIO_ES7210_CONNECTED_MIC_MASK    (BSP_AUDIO_ES7210_MIC_MASK_FL_FR | BSP_AUDIO_ES7210_MIC3_RE_MASK)
+
+/*
+ * ES7210 serialized TDM order from esp_codec_dev: ch3, ch1, ch2, ch4.
+ * Use these slot masks only with esp_codec_dev_sample_info_t.channel_mask.
+ * Do not reuse the physical MIC masks above as TDM slot masks.
+ */
+#define BSP_AUDIO_TDM_SLOT_COUNT               (4U)
+#define BSP_AUDIO_TDM_SLOT_RE                  (0U)  /* slot0 = MIC3 = RE */
+#define BSP_AUDIO_TDM_SLOT_FL                  (1U)  /* slot1 = MIC1 = FL */
+#define BSP_AUDIO_TDM_SLOT_FR                  (2U)  /* slot2 = MIC2 = FR */
+#define BSP_AUDIO_TDM_SLOT_NA                  (3U)  /* slot3 = MIC4 = not connected */
+#define BSP_AUDIO_TDM_SLOT_MASK_RE             ESP_CODEC_DEV_MAKE_CHANNEL_MASK(BSP_AUDIO_TDM_SLOT_RE)
+#define BSP_AUDIO_TDM_SLOT_MASK_FL             ESP_CODEC_DEV_MAKE_CHANNEL_MASK(BSP_AUDIO_TDM_SLOT_FL)
+#define BSP_AUDIO_TDM_SLOT_MASK_FR             ESP_CODEC_DEV_MAKE_CHANNEL_MASK(BSP_AUDIO_TDM_SLOT_FR)
+#define BSP_AUDIO_TDM_SLOT_MASK_NA             ESP_CODEC_DEV_MAKE_CHANNEL_MASK(BSP_AUDIO_TDM_SLOT_NA)
+#define BSP_AUDIO_TDM_SLOT_MASK_FL_FR          (BSP_AUDIO_TDM_SLOT_MASK_FL | BSP_AUDIO_TDM_SLOT_MASK_FR)
+
 /**************************************************************************************************
  *
  * I2S audio interface
@@ -152,13 +180,17 @@ esp_err_t bsp_audio_init_tx_std_rx_tdm(const i2s_std_config_t *tx_config,
  * @brief Initialize the 24 kHz voice audio bus profile
  *
  * The physical bus uses 24 kHz, 16-bit stereo STD for TX and 24 kHz, 16-bit TDM slots 0..3 for RX.
- * RX uses four total slots, BCLK divider 8, and MCLK x256. The ES7210 codec interface enables MIC1
- * through MIC4 so esp_codec_dev can retain the four-channel TDM frame.
+ * RX keeps four total slots, BCLK divider 8, and MCLK x256. The ES7210 enables the connected MIC1,
+ * MIC2, and MIC3 inputs; the unconnected MIC4 input remains disabled while slot3 stays in the frame.
  *
- * @note This configures the physical bus only. It does not select a record channel mask and does not
- *       imply AEC or a reference channel. For single-microphone capture, open the record codec with
- *       channel=4 and channel_mask=ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0), then set gain for that mask.
- *       Callers may choose another channel mask when their capture topology requires it.
+ * @note This configures the physical bus only and does not imply AEC or a reference channel.
+ * @note esp_codec_dev_sample_info_t.channel is the physical TDM slot count, not the number of
+ *       selected PCM channels. Keep channel=BSP_AUDIO_TDM_SLOT_COUNT.
+ * @note For FL-only capture, use channel_mask=BSP_AUDIO_TDM_SLOT_MASK_FL. For FL+FR capture, use
+ *       channel_mask=BSP_AUDIO_TDM_SLOT_MASK_FL_FR. Other slot combinations remain caller-selected.
+ * @note Input gain uses the physical MIC namespace instead: FL is BSP_AUDIO_ES7210_MIC1_FL_MASK and
+ *       FL+FR is BSP_AUDIO_ES7210_MIC_MASK_FL_FR. Physical MIC masks and TDM slot masks must not be
+ *       interchanged even when an individual bit value happens to match.
  *
  * @return
  *      - ESP_OK                On success
@@ -198,8 +230,9 @@ esp_codec_dev_handle_t bsp_audio_codec_speaker_init(void);
  * @brief Initialize or get the BSP-owned microphone codec device
  *
  * If audio is not initialized, this function initializes the legacy STD/STD mode. In mixed
- * STD TX/TDM RX mode, the ES7210 enables MIC1 through MIC4; esp_codec_dev_open() still controls
- * which packed TDM channels are returned through its channel_mask.
+ * STD TX/TDM RX mode, the ES7210 enables connected physical inputs MIC1, MIC2, and MIC3 while the
+ * four-slot TDM frame remains intact. esp_codec_dev_open() selects packed TDM slots through
+ * esp_codec_dev_sample_info_t.channel_mask.
  *
  * @return BSP-owned codec device handle, or NULL when an error occurs
  */

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
@@ -12,7 +12,7 @@
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 #include "lvgl.h"
-#include "esp_lvgl_port.h"
+#include "esp_lv_adapter.h"
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /**************************************************************************************************
@@ -243,22 +243,19 @@ esp_err_t bsp_sdcard_unmount(void);
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
-#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 50) // Frame buffer size in pixels
-#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
-
 /**
  * @brief BSP display configuration structure
  *
  */
 typedef struct {
-    lvgl_port_cfg_t lvgl_port_cfg;  /*!< LVGL port configuration */
-    uint32_t        buffer_size;    /*!< Size of the buffer for the screen in pixels */
-    bool            double_buffer;  /*!< True, if should be allocated two buffers */
+    esp_lv_adapter_config_t          lv_adapter_cfg;   /*!< LVGL adapter configuration */
+    esp_lv_adapter_rotation_t        rotation;         /*!< Display rotation */
+    esp_lv_adapter_tear_avoid_mode_t tear_avoid_mode;  /*!< Tearing avoidance mode */
     struct {
-        unsigned int buff_dma: 1;    /*!< Allocated LVGL buffer will be DMA capable */
-        unsigned int buff_spiram: 1; /*!< Allocated LVGL buffer will be in PSRAM */
-        unsigned int sw_rotate: 1;   /*!< Use software rotation (slower), The feature is unavailable under avoid-tear mode */
-    } flags;
+        unsigned int swap_xy: 1;   /*!< Swap X and Y after reading touch coordinates */
+        unsigned int mirror_x: 1;  /*!< Mirror X after reading touch coordinates */
+        unsigned int mirror_y: 1;  /*!< Mirror Y after reading touch coordinates */
+    } touch_flags;
 } bsp_display_cfg_t;
 
 /**
@@ -281,7 +278,7 @@ lv_display_t *bsp_display_start(void);
  *
  * @return Pointer to LVGL display or NULL when error occured
  */
-lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg);
+lv_display_t *bsp_display_start_with_config(bsp_display_cfg_t *cfg);
 
 /**
  * @brief Get pointer to input device (touch, buttons, ...)

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/esp32_p4_wifi6_touch_lcd_4b.h
@@ -114,17 +114,17 @@ i2c_master_bus_handle_t bsp_i2c_get_handle(void);
 #define BSP_AUDIO_ES7210_CONNECTED_MIC_MASK    (BSP_AUDIO_ES7210_MIC_MASK_FL_FR | BSP_AUDIO_ES7210_MIC3_RE_MASK)
 
 /*
- * ES7210 serialized TDM order from esp_codec_dev: ch3, ch1, ch2, ch4.
+ * ES7210 serialized TDM order verified on hardware: ch1, ch3, ch2, ch4.
  * Use these slot masks only with esp_codec_dev_sample_info_t.channel_mask.
  * Do not reuse the physical MIC masks above as TDM slot masks.
  */
 #define BSP_AUDIO_TDM_SLOT_COUNT               (4U)
-#define BSP_AUDIO_TDM_SLOT_RE                  (0U)  /* slot0 = MIC3 = RE */
-#define BSP_AUDIO_TDM_SLOT_FL                  (1U)  /* slot1 = MIC1 = FL */
+#define BSP_AUDIO_TDM_SLOT_FL                  (0U)  /* slot0 = MIC1 = FL */
+#define BSP_AUDIO_TDM_SLOT_RE                  (1U)  /* slot1 = MIC3 = RE */
 #define BSP_AUDIO_TDM_SLOT_FR                  (2U)  /* slot2 = MIC2 = FR */
 #define BSP_AUDIO_TDM_SLOT_NA                  (3U)  /* slot3 = MIC4 = not connected */
-#define BSP_AUDIO_TDM_SLOT_MASK_RE             ESP_CODEC_DEV_MAKE_CHANNEL_MASK(BSP_AUDIO_TDM_SLOT_RE)
 #define BSP_AUDIO_TDM_SLOT_MASK_FL             ESP_CODEC_DEV_MAKE_CHANNEL_MASK(BSP_AUDIO_TDM_SLOT_FL)
+#define BSP_AUDIO_TDM_SLOT_MASK_RE             ESP_CODEC_DEV_MAKE_CHANNEL_MASK(BSP_AUDIO_TDM_SLOT_RE)
 #define BSP_AUDIO_TDM_SLOT_MASK_FR             ESP_CODEC_DEV_MAKE_CHANNEL_MASK(BSP_AUDIO_TDM_SLOT_FR)
 #define BSP_AUDIO_TDM_SLOT_MASK_NA             ESP_CODEC_DEV_MAKE_CHANNEL_MASK(BSP_AUDIO_TDM_SLOT_NA)
 #define BSP_AUDIO_TDM_SLOT_MASK_FL_FR          (BSP_AUDIO_TDM_SLOT_MASK_FL | BSP_AUDIO_TDM_SLOT_MASK_FR)
@@ -180,14 +180,15 @@ esp_err_t bsp_audio_init_tx_std_rx_tdm(const i2s_std_config_t *tx_config,
  * @brief Initialize the 24 kHz voice audio bus profile
  *
  * The physical bus uses 24 kHz, 16-bit stereo STD for TX and 24 kHz, 16-bit TDM slots 0..3 for RX.
- * RX keeps four total slots, BCLK divider 8, and MCLK x256. The ES7210 enables the connected MIC1,
- * MIC2, and MIC3 inputs; the unconnected MIC4 input remains disabled while slot3 stays in the frame.
+ * RX keeps four total slots, BCLK divider 8, and MCLK x256. The hardware-verified serialized order
+ * is slot0=MIC1/FL, slot1=MIC3/RE, slot2=MIC2/FR, and slot3=MIC4/NA. The ES7210 enables connected
+ * MIC1, MIC2, and MIC3 inputs; the unconnected MIC4 input remains disabled.
  *
  * @note This configures the physical bus only and does not imply AEC or a reference channel.
  * @note esp_codec_dev_sample_info_t.channel is the physical TDM slot count, not the number of
  *       selected PCM channels. Keep channel=BSP_AUDIO_TDM_SLOT_COUNT.
  * @note For FL-only capture, use channel_mask=BSP_AUDIO_TDM_SLOT_MASK_FL. For FL+FR capture, use
- *       channel_mask=BSP_AUDIO_TDM_SLOT_MASK_FL_FR. Other slot combinations remain caller-selected.
+ *       channel_mask=BSP_AUDIO_TDM_SLOT_MASK_FL_FR. These resolve to slot0 and slot0|slot2.
  * @note Input gain uses the physical MIC namespace instead: FL is BSP_AUDIO_ES7210_MIC1_FL_MASK and
  *       FL+FR is BSP_AUDIO_ES7210_MIC_MASK_FL_FR. Physical MIC masks and TDM slot masks must not be
  *       interchanged even when an individual bit value happens to match.

--- a/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/touch.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_4b/include/bsp/touch.h
@@ -10,7 +10,11 @@ extern "C" {
  *
  */
 typedef struct {
-    void *dummy;    /*!< Prepared for future use. */
+    struct {
+        unsigned int swap_xy: 1;   /*!< Swap X and Y after reading coordinates */
+        unsigned int mirror_x: 1;  /*!< Mirror X after reading coordinates */
+        unsigned int mirror_y: 1;  /*!< Mirror Y after reading coordinates */
+    } flags;
 } bsp_touch_config_t;
 
 /**

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/Kconfig
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/Kconfig
@@ -79,28 +79,11 @@ menu "Board Support Package(ESP32-P4)"
     menu "Display"
         config BSP_LCD_DPI_BUFFER_NUMS
             int "Set number of frame buffers"
-            default 1
+            default 3
             range 1 3
             help
                 Let DPI LCD driver create a specified number of frame-size buffers. Only when it is set to multiple can the avoiding tearing be turned on.
 
-        config BSP_DISPLAY_LVGL_AVOID_TEAR
-            bool "Avoid tearing effect"
-            depends on BSP_LCD_DPI_BUFFER_NUMS > 1
-            default "n"
-            help
-                Avoid tearing effect through LVGL buffer mode and double frame buffers of RGB LCD. This feature is only available for RGB LCD.
-
-        choice BSP_DISPLAY_LVGL_MODE
-            depends on BSP_DISPLAY_LVGL_AVOID_TEAR
-            prompt "Select LVGL buffer mode"
-            default BSP_DISPLAY_LVGL_FULL_REFRESH
-            config BSP_DISPLAY_LVGL_FULL_REFRESH
-                bool "Full refresh"
-            config BSP_DISPLAY_LVGL_DIRECT_MODE
-                bool "Direct mode"
-        endchoice
-            
         config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
         int "LEDC channel index"
         default 1

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/README.md
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/README.md
@@ -22,7 +22,7 @@ Selection color format `Board Support Package(ESP32-P4) --> Display --> Select L
 |  Capability |     Available    |                                                 Component                                                |Version|
 |-------------|------------------|----------------------------------------------------------------------------------------------------------|-------|
 |   DISPLAY   |:heavy_check_mark:|    [espressif/esp_lcd_ek79007](https://components.espressif.com/components/espressif/esp_lcd_ek79007)    |  1.*  |
-|  LVGL_PORT  |:heavy_check_mark:|      [espressif/esp_lvgl_port](https://components.espressif.com/components/espressif/esp_lvgl_port)      |   ^2  |
+| LVGL_ADAPTER|:heavy_check_mark:| [espressif/esp_lvgl_adapter](https://components.espressif.com/components/espressif/esp_lvgl_adapter)    | ~0.6  |
 |    TOUCH    |:heavy_check_mark:|[espressif/esp_lcd_touch_gt911](https://components.espressif.com/components/espressif/esp_lcd_touch_gt911)|   ^1  |
 |   BUTTONS   |        :x:       |                                                                                                          |       |
 |    AUDIO    |:heavy_check_mark:|      [espressif/esp_codec_dev](https://components.espressif.com/components/espressif/esp_codec_dev)      | 1.2.* |

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
@@ -502,6 +502,17 @@ err:
 
 esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t *ret_touch)
 {
+    const bsp_touch_config_t default_config = {
+        .flags = {
+            .swap_xy = 0,
+            .mirror_x = 1,
+            .mirror_y = 1,
+        },
+    };
+    if (config == NULL) {
+        config = &default_config;
+    }
+
     /* Initilize I2C */
     BSP_ERROR_CHECK_RETURN_ERR(bsp_i2c_init());
 
@@ -516,9 +527,9 @@ esp_err_t bsp_touch_new(const bsp_touch_config_t *config, esp_lcd_touch_handle_t
             .interrupt = 0,
         },
         .flags = {
-            .swap_xy = 0,
-            .mirror_x = 1,
-            .mirror_y = 1,
+            .swap_xy = config->flags.swap_xy,
+            .mirror_x = config->flags.mirror_x,
+            .mirror_y = config->flags.mirror_y,
         },
     };
     esp_lcd_panel_io_handle_t tp_io_handle = NULL;
@@ -550,103 +561,74 @@ static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
 
     /* Add LCD screen */
     ESP_LOGD(TAG, "Add LCD screen");
-    const lvgl_port_display_cfg_t disp_cfg = {
-        .io_handle = lcd_panels.io,
-        .panel_handle = lcd_panels.panel,
-        .control_handle = lcd_panels.control,
-        .buffer_size = cfg->buffer_size,
-        .double_buffer = cfg->double_buffer,
-        .hres = BSP_LCD_H_RES,
-        .vres = BSP_LCD_V_RES,
-        .monochrome = false,
-        /* Rotation values must be same as used in esp_lcd for initial settings of the screen */
-        .rotation = {
-            .swap_xy = false,
-            .mirror_x = true,
-            .mirror_y = true,
+    const esp_lv_adapter_display_config_t disp_cfg = {
+        .panel = lcd_panels.panel,
+        .panel_io = lcd_panels.io,
+        .profile = {
+            .interface = ESP_LV_ADAPTER_PANEL_IF_MIPI_DSI,
+            .rotation = cfg->rotation,
+            .hor_res = BSP_LCD_H_RES,
+            .ver_res = BSP_LCD_V_RES,
+            .buffer_height = 50,
+            .use_psram = false,
+            .enable_ppa_accel = false,
+            .require_double_buffer = false,
         },
-#if LVGL_VERSION_MAJOR >= 9
-#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
-        .color_format = LV_COLOR_FORMAT_RGB888,
-#else
-        .color_format = LV_COLOR_FORMAT_RGB565,
-#endif
-#endif
-        .flags = {
-            .buff_dma = cfg->flags.buff_dma,
-            .buff_spiram = cfg->flags.buff_spiram,
-#if LVGL_VERSION_MAJOR >= 9
-            .swap_bytes = (BSP_LCD_BIGENDIAN ? true : false),
-#endif
-#if CONFIG_BSP_DISPLAY_LVGL_AVOID_TEAR
-            .sw_rotate = false, /* Avoid tearing is not supported for SW rotation */
-#else
-            .sw_rotate = cfg->flags.sw_rotate, /* Only SW rotation is supported for 90° and 270° */
-#endif
-#if CONFIG_BSP_DISPLAY_LVGL_FULL_REFRESH
-            .full_refresh = true,
-#elif CONFIG_BSP_DISPLAY_LVGL_DIRECT_MODE
-            .direct_mode = true,
-#endif
-        }};
+        .tear_avoid_mode = cfg->tear_avoid_mode,
+    };
 
-    const lvgl_port_display_dsi_cfg_t dpi_cfg = {
-        .flags = {
-#if CONFIG_BSP_DISPLAY_LVGL_AVOID_TEAR
-            .avoid_tearing = true,
-#else
-            .avoid_tearing = false,
-#endif
-        }};
-
-    return lvgl_port_add_disp_dsi(&disp_cfg, &dpi_cfg);
+    return esp_lv_adapter_register_display(&disp_cfg);
 }
 
-static lv_indev_t *bsp_display_indev_init(lv_display_t *disp)
+static lv_indev_t *bsp_display_indev_init(const bsp_display_cfg_t *cfg, lv_display_t *disp)
 {
+    assert(cfg != NULL);
     esp_lcd_touch_handle_t tp;
-    BSP_ERROR_CHECK_RETURN_NULL(bsp_touch_new(NULL, &tp));
+    const bsp_touch_config_t touch_config = {
+        .flags = {
+            .swap_xy = cfg->touch_flags.swap_xy,
+            .mirror_x = cfg->touch_flags.mirror_x,
+            .mirror_y = cfg->touch_flags.mirror_y,
+        },
+    };
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_touch_new(&touch_config, &tp));
     assert(tp);
 
     /* Add touch input (for selected screen) */
-    const lvgl_port_touch_cfg_t touch_cfg = {
-        .disp = disp,
-        .handle = tp,
-    };
+    const esp_lv_adapter_touch_config_t touch_cfg = ESP_LV_ADAPTER_TOUCH_DEFAULT_CONFIG(disp, tp);
 
-    return lvgl_port_add_touch(&touch_cfg);
+    return esp_lv_adapter_register_touch(&touch_cfg);
 }
 
 lv_display_t *bsp_display_start(void)
 {
     bsp_display_cfg_t cfg = {
-        .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG(),
-        .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
-        .double_buffer = BSP_LCD_DRAW_BUFF_DOUBLE,
-        .flags = {
-#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
-            .buff_dma = false,
-#else
-            .buff_dma = true,
-#endif
-            .buff_spiram = false,
-            .sw_rotate = true,
-        }};
+        .lv_adapter_cfg = ESP_LV_ADAPTER_DEFAULT_CONFIG(),
+        .rotation = ESP_LV_ADAPTER_ROTATE_180,
+        .tear_avoid_mode = ESP_LV_ADAPTER_TEAR_AVOID_MODE_TRIPLE_PARTIAL,
+        .touch_flags = {
+            .swap_xy = 0,
+            .mirror_x = 1,
+            .mirror_y = 1,
+        },
+    };
     return bsp_display_start_with_config(&cfg);
 }
 
-lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
+lv_display_t *bsp_display_start_with_config(bsp_display_cfg_t *cfg)
 {
     lv_display_t *disp;
 
     assert(cfg != NULL);
-    BSP_ERROR_CHECK_RETURN_NULL(lvgl_port_init(&cfg->lvgl_port_cfg));
+    BSP_ERROR_CHECK_RETURN_NULL(esp_lv_adapter_init(&cfg->lv_adapter_cfg));
 
     BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
 
     BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
 
-    BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(disp), NULL);
+    BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(cfg, disp), NULL);
+
+    ESP_ERROR_CHECK(esp_lv_adapter_start());
 
     return disp;
 }
@@ -663,12 +645,12 @@ void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
 
 bool bsp_display_lock(uint32_t timeout_ms)
 {
-    return lvgl_port_lock(timeout_ms);
+    return esp_lv_adapter_lock(timeout_ms) == ESP_OK;
 }
 
 void bsp_display_unlock(void)
 {
-    lvgl_port_unlock();
+    esp_lv_adapter_unlock();
 }
 
 #endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
@@ -643,7 +643,7 @@ void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
     lv_disp_set_rotation(disp, rotation);
 }
 
-bool bsp_display_lock(uint32_t timeout_ms)
+bool bsp_display_lock(int32_t timeout_ms)
 {
     return esp_lv_adapter_lock(timeout_ms) == ESP_OK;
 }

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/idf_component.yml
@@ -4,10 +4,10 @@ dependencies:
     version: "~1.5"
   esp_lcd_ek79007: "^2.0.2~1"
   esp_lcd_touch_gt911: ^1
-  espressif/esp_lvgl_port:
+  espressif/esp_lvgl_adapter:
     public: true
-    version: ^2
-  idf: '>=5.3'
+    version: "~0.6"
+  idf: '>=5.5'
   lvgl/lvgl: '>=8,<10'
   usb:
     version: "^1.0.0"
@@ -21,4 +21,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-7b.htm
-version: 2.0.0
+version: 3.0.0

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/esp32_p4_wifi6_touch_lcd_7b.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/esp32_p4_wifi6_touch_lcd_7b.h
@@ -23,7 +23,7 @@
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 #include "lvgl.h"
-#include "esp_lvgl_port.h"
+#include "esp_lv_adapter.h"
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /**************************************************************************************************
@@ -255,22 +255,19 @@ esp_err_t bsp_sdcard_unmount(void);
 
 #if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
 
-#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 50) // Frame buffer size in pixels
-#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
-
 /**
  * @brief BSP display configuration structure
  *
  */
 typedef struct {
-    lvgl_port_cfg_t lvgl_port_cfg;  /*!< LVGL port configuration */
-    uint32_t        buffer_size;    /*!< Size of the buffer for the screen in pixels */
-    bool            double_buffer;  /*!< True, if should be allocated two buffers */
+    esp_lv_adapter_config_t          lv_adapter_cfg;   /*!< LVGL adapter configuration */
+    esp_lv_adapter_rotation_t        rotation;         /*!< Display rotation */
+    esp_lv_adapter_tear_avoid_mode_t tear_avoid_mode;  /*!< Tearing avoidance mode */
     struct {
-        unsigned int buff_dma: 1;    /*!< Allocated LVGL buffer will be DMA capable */
-        unsigned int buff_spiram: 1; /*!< Allocated LVGL buffer will be in PSRAM */
-        unsigned int sw_rotate: 1;   /*!< Use software rotation (slower), The feature is unavailable under avoid-tear mode */
-    } flags;
+        unsigned int swap_xy: 1;   /*!< Swap X and Y after reading touch coordinates */
+        unsigned int mirror_x: 1;  /*!< Mirror X after reading touch coordinates */
+        unsigned int mirror_y: 1;  /*!< Mirror Y after reading touch coordinates */
+    } touch_flags;
 } bsp_display_cfg_t;
 
 /**
@@ -293,7 +290,7 @@ lv_display_t *bsp_display_start(void);
  *
  * @return Pointer to LVGL display or NULL when error occured
  */
-lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg);
+lv_display_t *bsp_display_start_with_config(bsp_display_cfg_t *cfg);
 
 /**
  * @brief Get pointer to input device (touch, buttons, ...)

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/esp32_p4_wifi6_touch_lcd_7b.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/esp32_p4_wifi6_touch_lcd_7b.h
@@ -304,11 +304,11 @@ lv_indev_t *bsp_display_get_input_dev(void);
 /**
  * @brief Take LVGL mutex
  *
- * @param timeout_ms Timeout in [ms]. 0 will block indefinitely.
+ * @param timeout_ms Timeout in [ms]. -1 will block indefinitely.
  * @return true  Mutex was taken
  * @return false Mutex was NOT taken
  */
-bool bsp_display_lock(uint32_t timeout_ms);
+bool bsp_display_lock(int32_t timeout_ms);
 
 /**
  * @brief Give LVGL mutex

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/touch.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/touch.h
@@ -26,7 +26,11 @@ extern "C" {
  *
  */
 typedef struct {
-    void *dummy;    /*!< Prepared for future use. */
+    struct {
+        unsigned int swap_xy: 1;   /*!< Swap X and Y after reading coordinates */
+        unsigned int mirror_x: 1;  /*!< Mirror X after reading coordinates */
+        unsigned int mirror_y: 1;  /*!< Mirror Y after reading coordinates */
+    } flags;
 } bsp_touch_config_t;
 
 /**


### PR DESCRIPTION
## Summary

- migrate esp32_p4_nano, esp32_p4_wifi6_touch_lcd_4b, and esp32_p4_wifi6_touch_lcd_7b from esp_lvgl_port to esp_lvgl_adapter
- register MIPI DSI displays and touch input through the adapter while preserving board rotation and touch mappings
- enable triple-partial tearing avoidance, align the minimum ESP-IDF version with adapter 0.6, and bump BSP major versions
- preserve bsp_display_lock(-1) as an infinite wait across all three migrated BSPs
- add compatible esp32_p4_wifi6_touch_lcd_4b APIs for STD TX plus TDM RX, including a 24 kHz, 16-bit, four-slot voice bus profile
- enable connected ES7210 inputs MIC1, MIC2, and MIC3 while retaining four physical TDM slots; MIC4 is unconnected and disabled
- document the hardware-verified ES7210 serialized order as slot0=MIC1/FL, slot1=MIC3/RE, slot2=MIC2/FR, and slot3=MIC4/NA
- keep channel-mask policy with the caller: channel remains 4, FL-only uses slot0, FL+FR uses slot0|slot2, and neither path requires AEC or a reference channel
- expose separate physical MIC gain masks and serialized TDM slot masks so the two namespaces are not interchanged
- add BSP-owned audio teardown and complete initialization-failure cleanup while preserving bsp_audio_init() STD/STD behavior

## Validation

- ESP-IDF v5.5.4: component self-check builds for all three migrated BSPs
- ESP-IDF v5.5.4: esp32_p4_wifi6_touch_lcd_4b component self-check after the mixed audio API update, using esp_codec_dev 1.5.11
- hardware slot-peak diagnostics confirm active microphones on slot0 and slot2 and the serialized order ch1,ch3,ch2,ch4
- latest slot mapping correction: git diff --check; downstream full firmware build remains deferred