### PR TITLE
ci: require a stable aggregate check

### DIFF
--- a/.github/workflows/component_self_check.yml
+++ b/.github/workflows/component_self_check.yml
@@ -56,3 +56,24 @@ jobs:
         run: |
           . "$IDF_PATH/export.sh"
           python .github/scripts/build_changed_component.py
+
+  ci-gate:
+    needs:
+      - manifest-check
+      - build-components
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all CI jobs passed
+        env:
+          MANIFEST_RESULT: ${{ needs.manifest-check.result }}
+          BUILD_RESULT: ${{ needs.build-components.result }}
+          BUILD_COUNT: ${{ needs.manifest-check.outputs.count }}
+        shell: bash
+        run: |
+          test "$MANIFEST_RESULT" = "success"
+          if [ "$BUILD_COUNT" = "0" ]; then
+            test "$BUILD_RESULT" = "skipped"
+          else
+            test "$BUILD_RESULT" = "success"
+          fi


### PR DESCRIPTION
## Summary

- add a stable `ci-gate` job after manifest validation and component builds
- fail the gate if manifest validation or any required component build fails or is cancelled
- allow the gate to pass when no component build is required

This gives branch rules a single stable status check that represents the complete CI result, including the dynamic build matrix.