### PR TITLE
fix: resolve P4 LCD BSP panel dependency

### DIFF
--- a/.github/scripts/component_self_check.py
+++ b/.github/scripts/component_self_check.py
@@ -261,6 +261,24 @@ def check_bsp_codec_dependency(components):
     return errors
 
 
+def check_p4_lcd_x_panel_dependencies(components):
+    component_dir = "bsp/esp32_p4_wifi6_touch_lcd_x"
+    if component_dir not in components:
+        return []
+
+    manifest_path = REPO / component_dir / "idf_component.yml"
+    dependencies = load_manifest_file(manifest_path).get("dependencies") or {}
+    expected = {
+        "esp_lcd_jd9365": "^2.0.0",
+        "waveshare/esp_lcd_ili9881c": "^2.0.0",
+    }
+    errors = []
+    for dependency, version in expected.items():
+        if str(dependencies.get(dependency)) != version:
+            errors.append(f"{manifest_path.relative_to(REPO)}: {dependency} version must be {version!r}")
+    return errors
+
+
 def write_outputs(components):
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
@@ -288,6 +306,7 @@ def main():
 
     errors.extend(check_version_bumps(base_ref, components))
     errors.extend(check_bsp_codec_dependency(output_components))
+    errors.extend(check_p4_lcd_x_panel_dependencies(output_components))
     write_outputs(output_components)
 
     print(f"Base ref: {base_ref}")

--- a/bsp/esp32_p4_wifi6_touch_lcd_x/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_x/idf_component.yml
@@ -14,7 +14,7 @@ dependencies:
     rules:
       - if: "idf_version >=6.0"
   esp_lcd_jd9365: "^2.0.0"
-  esp_lcd_ili9881c: "^2.0.0"
+  waveshare/esp_lcd_ili9881c: "^2.0.0"
 description: ESP32-P4 HMI Touch All-in-One Machine
 repository: git://github.com/WaveshareCloud/Waveshare-ESP32-components.git
 tags:
@@ -22,4 +22,4 @@ tags:
 targets:
 - esp32p4
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 2.0.1
+version: 2.0.2


### PR DESCRIPTION
Fixes #187

Scope: explicitly resolve the P4 LCD X ILI9881C panel dependency to waveshare/esp_lcd_ili9881c and bump the BSP to 2.0.2.

Validation: manifest static self-check and diff whitespace check passed.

No local build or Registry release was performed.