### PR TITLE
feat: add ESP32-P4 LCD-5 board support

### DIFF
--- a/.github/scripts/component_self_check.py
+++ b/.github/scripts/component_self_check.py
@@ -10,6 +10,22 @@ from pathlib import Path
 REPO = Path.cwd()
 SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
 COMPONENT_ROOTS = ("bsp", "sensor", "display/lcd", "display/oled", "display/touch", "lora")
+LCD5_BSP_DIR = "bsp/esp32_p4_wifi6_touch_lcd_5"
+HX8394_DIR = "display/lcd/esp_lcd_hx8394"
+LCD5_REQUIRED_FILES = {
+    "CMakeLists.txt",
+    "Kconfig",
+    "LICENSE",
+    "README.md",
+    "esp32_p4_wifi6_touch_lcd_5.c",
+    "idf_component.yml",
+    "include/bsp/config.h",
+    "include/bsp/display.h",
+    "include/bsp/esp-bsp.h",
+    "include/bsp/esp32_p4_wifi6_touch_lcd_5.h",
+    "include/bsp/touch.h",
+    "priv_include/bsp_err_check.h",
+}
 
 
 def run_git(*args, check=True):
@@ -41,6 +57,8 @@ def parse_manifest_text(text, source):
 
         if stripped.startswith("version:"):
             data["version"] = strip_scalar(stripped.split(":", 1)[1])
+        elif stripped.startswith("repository:"):
+            data["repository"] = strip_scalar(stripped.split(":", 1)[1])
         elif stripped == "targets:":
             targets = []
             i += 1
@@ -140,6 +158,95 @@ def discover_component_dirs():
                 continue
             component_dirs.add(manifest.parent.relative_to(REPO).as_posix())
     return component_dirs
+
+
+def check_lcd5_hx8394_contract(upload_dirs):
+    """Keep the LCD-5 BSP and HX8394 driver integration explicit and reviewable."""
+    errors = []
+    hx_dir = REPO / HX8394_DIR
+    bsp_dir = REPO / LCD5_BSP_DIR
+    hx_manifest = load_manifest_file(hx_dir / "idf_component.yml")
+    bsp_manifest = load_manifest_file(bsp_dir / "idf_component.yml")
+    hx_kconfig = (hx_dir / "Kconfig").read_text(encoding="utf-8")
+    bsp_kconfig = (bsp_dir / "Kconfig").read_text(encoding="utf-8")
+    hx_source = (hx_dir / "esp_lcd_hx8394.c").read_text(encoding="utf-8")
+    hx_readme = (hx_dir / "README.md").read_text(encoding="utf-8")
+    bsp_readme = (bsp_dir / "README.md").read_text(encoding="utf-8")
+    root_readme = (REPO / "README.md").read_text(encoding="utf-8")
+
+    try:
+        if semver_tuple(hx_manifest.get("version", ""), f"{HX8394_DIR}/idf_component.yml") < (2, 1, 0):
+            errors.append(f"{HX8394_DIR}/idf_component.yml: expected version >= 2.1.0")
+    except RuntimeError as exc:
+        errors.append(str(exc))
+    if not re.search(r"config ESP_LCD_HX8394_SKIP_I2C_INIT\s+bool.*?default n", hx_kconfig, re.DOTALL):
+        errors.append(f"{HX8394_DIR}/Kconfig: missing ESP_LCD_HX8394_SKIP_I2C_INIT default n")
+
+    guard_start = hx_source.find("#if !CONFIG_ESP_LCD_HX8394_SKIP_I2C_INIT")
+    guard_end = hx_source.find("#endif // !CONFIG_ESP_LCD_HX8394_SKIP_I2C_INIT", guard_start)
+    if guard_start < 0 or guard_end < 0:
+        errors.append(f"{HX8394_DIR}/esp_lcd_hx8394.c: missing complete I2C opt-out guard")
+    else:
+        for token in (
+            "i2c_config_t conf",
+            "i2c_bus_create",
+            "i2c_bus_device_create",
+            "i2c_bus_write_bytes",
+            "i2c_bus_device_delete",
+            "vTaskDelay(pdMS_TO_TICKS(1000))",
+        ):
+            position = hx_source.find(token)
+            if not guard_start < position < guard_end:
+                errors.append(f"{HX8394_DIR}/esp_lcd_hx8394.c: {token} is outside the I2C opt-out guard")
+        if "#include \"sdkconfig.h\"" not in hx_source or "#ifndef CONFIG_ESP_LCD_HX8394_SKIP_I2C_INIT" not in hx_source:
+            errors.append(f"{HX8394_DIR}/esp_lcd_hx8394.c: missing generated-config fallback")
+
+    dependencies = bsp_manifest.get("dependencies") or {}
+    try:
+        if semver_tuple(bsp_manifest.get("version", ""), f"{LCD5_BSP_DIR}/idf_component.yml") < (1, 0, 1):
+            errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected version >= 1.0.1")
+    except RuntimeError as exc:
+        errors.append(str(exc))
+    if bsp_manifest.get("targets") != ["esp32p4"]:
+        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected esp32p4 target")
+    if dependencies.get("idf") != ">=5.4":
+        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected idf >=5.4")
+    codec_dep = dependencies.get("esp_codec_dev")
+    codec_version = codec_dep.get("version") if isinstance(codec_dep, dict) else codec_dep
+    if codec_version != "~1.5":
+        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected esp_codec_dev ~1.5")
+    hx_dependency = str(dependencies.get("waveshare/esp_lcd_hx8394", ""))
+    hx_dependency_match = re.fullmatch(r"\^(\d+\.\d+\.\d+)", hx_dependency)
+    if not hx_dependency_match:
+        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected a caret waveshare/esp_lcd_hx8394 SemVer dependency")
+    elif semver_tuple(hx_dependency_match.group(1), f"{LCD5_BSP_DIR}/idf_component.yml") < (2, 1, 0):
+        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected waveshare/esp_lcd_hx8394 minimum >= 2.1.0")
+    if bsp_manifest.get("repository") != "https://github.com/waveshareteam/Waveshare-ESP32-components.git":
+        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected canonical repository URL")
+    bridge = re.compile(
+        r"config BSP_LCD_HX8394_SKIP_I2C_INIT\s+bool\s+default y\s+select ESP_LCD_HX8394_SKIP_I2C_INIT",
+        re.DOTALL,
+    )
+    if not bridge.search(bsp_kconfig):
+        errors.append(f"{LCD5_BSP_DIR}/Kconfig: missing default-y HX8394 opt-out bridge")
+
+    actual_files = {
+        path.relative_to(bsp_dir).as_posix()
+        for path in bsp_dir.rglob("*")
+        if path.is_file()
+    }
+    missing_files = sorted(LCD5_REQUIRED_FILES - actual_files)
+    if missing_files:
+        errors.append(f"{LCD5_BSP_DIR}: missing required source BSP files: {', '.join(missing_files)}")
+    if LCD5_BSP_DIR not in upload_dirs:
+        errors.append(f"upload_component.yml: missing {LCD5_BSP_DIR}")
+    if "ESP32-P4-WIFI6-Touch-LCD-5" not in root_readme:
+        errors.append("README.md: missing LCD-5 BSP table entry")
+    if "ESP_LCD_HX8394_SKIP_I2C_INIT" not in hx_readme or "default" not in hx_readme:
+        errors.append(f"{HX8394_DIR}/README.md: missing default/opt-out documentation")
+    if "BSP_LCD_HX8394_SKIP_I2C_INIT" not in bsp_readme:
+        errors.append(f"{LCD5_BSP_DIR}/README.md: missing BSP opt-out rationale")
+    return errors
 
 
 def resolve_base_ref():
@@ -280,7 +387,7 @@ def main():
 
     unlisted = sorted(set(components) - upload_dirs)
     output_unlisted = sorted(set(output_components) - upload_dirs)
-    errors = []
+    errors = check_lcd5_hx8394_contract(upload_dirs)
     if unlisted:
         errors.extend(f"{item}: component is not listed in upload_component.yml" for item in unlisted)
     if output_unlisted:

--- a/.github/scripts/component_self_check.py
+++ b/.github/scripts/component_self_check.py
@@ -215,12 +215,13 @@ def check_lcd5_hx8394_contract(upload_dirs):
     codec_version = codec_dep.get("version") if isinstance(codec_dep, dict) else codec_dep
     if codec_version != "~1.5":
         errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected esp_codec_dev ~1.5")
-    hx_dependency = str(dependencies.get("waveshare/esp_lcd_hx8394", ""))
-    hx_dependency_match = re.fullmatch(r"\^(\d+\.\d+\.\d+)", hx_dependency)
-    if not hx_dependency_match:
-        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected a caret waveshare/esp_lcd_hx8394 SemVer dependency")
-    elif semver_tuple(hx_dependency_match.group(1), f"{LCD5_BSP_DIR}/idf_component.yml") < (2, 1, 0):
-        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected waveshare/esp_lcd_hx8394 minimum >= 2.1.0")
+    hx_dependency = dependencies.get("waveshare/esp_lcd_hx8394")
+    if hx_dependency != {
+        "git": "https://github.com/waveshareteam/Waveshare-ESP32-components.git",
+        "path": "display/lcd/esp_lcd_hx8394",
+        "version": "fc6e6d2d63aa314cdcec2e8912614aacff2fbd6d",
+    }:
+        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected immutable HX8394 PR/HIL validation pin")
     if bsp_manifest.get("repository") != "https://github.com/waveshareteam/Waveshare-ESP32-components.git":
         errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected canonical repository URL")
     bridge = re.compile(

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -54,6 +54,7 @@ jobs:
             display/touch/esp_lcd_touch_hi8561;
             bsp/esp32_p4_wifi6_touch_lcd_4b;
             bsp/esp32_p4_wifi6_touch_lcd_3_5;
+            bsp/esp32_p4_wifi6_touch_lcd_5;
             bsp/esp32_s3_touch_amoled_2_06;
             bsp/esp32_s3_touch_amoled_2_16;
             bsp/esp32_s3_touch_lcd_4b;

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ accelerate your project setup.
 | [ESP32-P4-86-Panel-ETH-2RO ](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm)<br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/e/s/esp32-p4-86-panel-eth-2ro-7.jpg">         | ✅        |
 | [ESP32-P4-WIFI6-Touch-LCD-XC ](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-3.4c.htm)<br/><img style="width: 150px; height: auto; display: block; margin: 0 auto;" src="https://www.waveshare.com/media/catalog/product/cache/1/image/800x800/9df78eab33525d08d6e5fb8d27136e95/e/s/esp32-p4-wifi6-touch-lcd-3.4c-1.jpg"> | ✅        |
 | [ESP32-P4-WIFI6-Touch-LCD-3.5](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-3.5.htm)                                                                                                                                                                                                                                    | ✅        |
+| [ESP32-P4-WIFI6-Touch-LCD-5](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-5.htm)                                                                                                                                                                                                                                      | ✅        |
 
 ### 2. **Display Drivers**
 

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/CMakeLists.txt
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+idf_component_register(
+    SRCS "esp32_p4_wifi6_touch_lcd_5.c"
+    INCLUDE_DIRS "include"
+    PRIV_INCLUDE_DIRS "priv_include"
+    REQUIRES driver esp_driver_gpio esp_driver_ledc esp_driver_i2c esp_driver_sdmmc esp_driver_i2s
+    PRIV_REQUIRES esp_lcd usb spiffs fatfs esp_driver_gpio esp_driver_ledc esp_driver_i2c esp_driver_sdmmc esp_driver_i2s
+)

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/Kconfig
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/Kconfig
@@ -1,0 +1,117 @@
+menu "Board Support Package(ESP32-P4)"
+
+    config BSP_ERROR_CHECK
+        bool "Enable error check in BSP"
+        default y
+        help
+            Error check assert the application before returning the error code.
+
+    config BSP_LCD_HX8394_SKIP_I2C_INIT
+        bool
+        default y
+        select ESP_LCD_HX8394_SKIP_I2C_INIT
+        help
+            This BSP owns its board-level I2C and power behavior, so it disables
+            the HX8394 driver's standalone board-specific I2C sequence.
+
+    menu "I2C"
+        config BSP_I2C_NUM
+            int "I2C peripheral index"
+            default 1
+            range 0 1
+            help
+                ESP32P4 has two I2C peripherals, pick the one you want to use.
+
+        config BSP_I2C_FAST_MODE
+            bool "Enable I2C fast mode"
+            default y
+            help
+                I2C has two speed modes: normal (100kHz) and fast (400kHz).
+
+        config BSP_I2C_CLK_SPEED_HZ
+            int
+            default 400000 if BSP_I2C_FAST_MODE
+            default 100000
+    endmenu
+
+    menu "I2S"
+        config BSP_I2S_NUM
+            int "I2S peripheral index"
+            default 1
+            range 0 2
+            help
+                ESP32P4 has three I2S peripherals, pick the one you want to use.
+    endmenu
+
+    menu "uSD card - Virtual File System"
+        config BSP_SD_FORMAT_ON_MOUNT_FAIL
+            bool "Format uSD card if mounting fails"
+            default n
+            help
+                The SDMMC host will format (FAT) the uSD card if it fails to mount the filesystem.
+
+        config BSP_SD_MOUNT_POINT
+            string "uSD card mount point"
+            default "/sdcard"
+            help
+                Mount point of the uSD card in the Virtual File System
+
+    endmenu
+
+    menu "SPIFFS - Virtual File System"
+        config BSP_SPIFFS_FORMAT_ON_MOUNT_FAIL
+            bool "Format SPIFFS if mounting fails"
+            default n
+            help
+                Format SPIFFS if it fails to mount the filesystem.
+
+        config BSP_SPIFFS_MOUNT_POINT
+            string "SPIFFS mount point"
+            default "/spiffs"
+            help
+                Mount point of SPIFFS in the Virtual File System.
+
+        config BSP_SPIFFS_PARTITION_LABEL
+            string "Partition label of SPIFFS"
+            default "storage"
+            help
+                Partition label which stores SPIFFS.
+
+        config BSP_SPIFFS_MAX_FILES
+            int "Max files supported for SPIFFS VFS"
+            default 5
+            help
+                Supported max files for SPIFFS in the Virtual File System.
+    endmenu
+
+    menu "Display"
+        config BSP_LCD_DPI_BUFFER_NUMS
+            int "Set number of frame buffers"
+            default 3
+            range 1 3
+            help
+                Let DPI LCD driver create a specified number of frame-size buffers. Only when it is set to multiple can the avoiding tearing be turned on.
+
+
+        config BSP_DISPLAY_BRIGHTNESS_LEDC_CH
+        int "LEDC channel index"
+        default 1
+        range 0 7
+        help
+            LEDC channel is used to generate PWM signal that controls display brightness.
+            Set LEDC index that should be used.
+
+        choice BSP_LCD_COLOR_FORMAT
+            prompt "Select LCD color format"
+            default BSP_LCD_COLOR_FORMAT_RGB565
+            help
+                Select the LCD color format RGB565/RGB888.
+
+            config BSP_LCD_COLOR_FORMAT_RGB565
+                bool "RGB565"
+            config BSP_LCD_COLOR_FORMAT_RGB888
+                bool "RGB888"
+        endchoice
+    endmenu
+
+endmenu

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/Kconfig
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/Kconfig
@@ -112,6 +112,15 @@ menu "Board Support Package(ESP32-P4)"
             config BSP_LCD_COLOR_FORMAT_RGB888
                 bool "RGB888"
         endchoice
+
+        config BSP_DISPLAY_LVGL_USE_PSRAM
+            bool "Use PSRAM for the LVGL draw buffers"
+            default y
+            help
+                Allocate the LVGL draw buffers from external PSRAM instead of
+                internal SRAM. Recommended for high resolution panels such as
+                the 720x1280 display of this board. Disable to keep the
+                buffers in internal SRAM.
     endmenu
 
 endmenu

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/LICENSE
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/README.md
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/README.md
@@ -1,0 +1,27 @@
+# BSP: Waveshare ESP32-P4-WIFI6-Touch-LCD-5
+
+[![Component Registry](https://components.espressif.com/components/waveshare/esp32_p4_wifi6_touch_lcd_5/badge.svg)](https://components.espressif.com/components/waveshare/esp32_p4_wifi6_touch_lcd_5)
+
+
+| HW version | BSP Version |
+| :--------: | :---------: |
+|    [V1.0](http://www.waveshare.com/wiki/ESP32-P4-WIFI6-Touch-LCD-5)    |      ^1     |
+
+## HX8394 initialization
+
+This BSP selects `ESP_LCD_HX8394_SKIP_I2C_INIT` through its hidden
+`BSP_LCD_HX8394_SKIP_I2C_INIT` bridge. The board BSP owns board-level I2C and
+power behavior, while the standalone HX8394 driver retains its default I2C
+sequence for other users.
+
+
+## BackLight
+```c
+bsp_display_brightness_init();
+
+bsp_display_backlight_on();
+
+bsp_display_backlight_off();
+
+bsp_display_brightness_set(100);
+```

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/esp32_p4_wifi6_touch_lcd_5.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/esp32_p4_wifi6_touch_lcd_5.c
@@ -1,0 +1,704 @@
+#include "sdkconfig.h"
+#include "driver/gpio.h"
+#include "driver/ledc.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_spiffs.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_mipi_dsi.h"
+#include "esp_ldo_regulator.h"
+#include "esp_vfs_fat.h"
+#include "usb/usb_host.h"
+#include "sd_pwr_ctrl_by_on_chip_ldo.h"
+#include "esp_lcd_hx8394.h"
+#include "bsp/esp32_p4_wifi6_touch_lcd_5.h"
+#include "bsp/display.h"
+#include "bsp/touch.h"
+#include "esp_lcd_touch_gt911.h"
+#include "bsp_err_check.h"
+#include "esp_codec_dev_defaults.h"
+
+static const char *TAG = "ESP32_P4_5";
+
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+static lv_indev_t *disp_indev = NULL;
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+
+sdmmc_card_t *bsp_sdcard = NULL; // Global uSD card handler
+static bool i2c_initialized = false;
+static TaskHandle_t usb_host_task; // USB Host Library task
+static esp_lcd_touch_handle_t tp = NULL;
+static esp_lcd_panel_handle_t panel_handle = NULL; // LCD panel handle
+static esp_lcd_panel_io_handle_t io_handle = NULL;
+static i2c_master_bus_handle_t i2c_handle = NULL; // I2C Handle
+uint8_t brightness;
+static i2s_chan_handle_t i2s_tx_chan = NULL;
+static i2s_chan_handle_t i2s_rx_chan = NULL;
+static const audio_codec_data_if_t *i2s_data_if = NULL; /* Codec data interface */
+#define BSP_ES7210_CODEC_ADDR ES7210_CODEC_DEFAULT_ADDR
+
+/* Can be used for `i2s_std_gpio_config_t` and/or `i2s_std_config_t` initialization */
+#define BSP_I2S_GPIO_CFG       \
+    {                          \
+        .mclk = BSP_I2S_MCLK,  \
+        .bclk = BSP_I2S_SCLK,  \
+        .ws = BSP_I2S_LCLK,    \
+        .dout = BSP_I2S_DOUT,  \
+        .din = BSP_I2S_DSIN,   \
+        .invert_flags = {      \
+            .mclk_inv = false, \
+            .bclk_inv = false, \
+            .ws_inv = false,   \
+        },                     \
+    }
+
+/* This configuration is used by default in `bsp_extra_audio_init()` */
+#define BSP_I2S_DUPLEX_MONO_CFG(_sample_rate)                                                         \
+    {                                                                                                 \
+        .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(_sample_rate),                                          \
+        .slot_cfg = I2S_STD_PHILIP_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO), \
+        .gpio_cfg = BSP_I2S_GPIO_CFG,                                                                 \
+    }
+
+esp_err_t bsp_i2c_init(void)
+{
+    /* I2C was initialized before */
+    if (i2c_initialized)
+    {
+        return ESP_OK;
+    }
+
+    i2c_master_bus_config_t i2c_bus_conf = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .sda_io_num = BSP_I2C_SDA,
+        .scl_io_num = BSP_I2C_SCL,
+        .i2c_port = BSP_I2C_NUM,
+    };
+    BSP_ERROR_CHECK_RETURN_ERR(i2c_new_master_bus(&i2c_bus_conf, &i2c_handle));
+
+    i2c_initialized = true;
+
+    return ESP_OK;
+}
+
+esp_err_t bsp_i2c_deinit(void)
+{
+    BSP_ERROR_CHECK_RETURN_ERR(i2c_del_master_bus(i2c_handle));
+    i2c_initialized = false;
+    return ESP_OK;
+}
+
+i2c_master_bus_handle_t bsp_i2c_get_handle(void)
+{
+    return i2c_handle;
+}
+
+static esp_err_t bsp_i2c_device_probe(uint8_t addr)
+{
+    return i2c_master_probe(i2c_handle, addr, 100);
+}
+
+esp_err_t bsp_sdcard_mount(void)
+{
+    const esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+#ifdef CONFIG_BSP_SD_FORMAT_ON_MOUNT_FAIL
+        .format_if_mount_failed = true,
+#else
+        .format_if_mount_failed = false,
+#endif
+        .max_files = 5,
+        .allocation_unit_size = 64 * 1024
+    };
+
+    sdmmc_host_t host = SDMMC_HOST_DEFAULT();
+    host.slot = SDMMC_HOST_SLOT_0;
+    host.max_freq_khz = SDMMC_FREQ_HIGHSPEED;
+
+    sd_pwr_ctrl_ldo_config_t ldo_config = {
+        .ldo_chan_id = 4,
+    };
+    sd_pwr_ctrl_handle_t pwr_ctrl_handle = NULL;
+    esp_err_t ret = sd_pwr_ctrl_new_on_chip_ldo(&ldo_config, &pwr_ctrl_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create a new on-chip LDO power control driver");
+        return ret;
+    }
+    host.pwr_ctrl_handle = pwr_ctrl_handle;
+
+    const sdmmc_slot_config_t slot_config = {
+        /* SD card is connected to Slot 0 pins. Slot 0 uses IO MUX, so not specifying the pins here */
+        .cd = SDMMC_SLOT_NO_CD,
+        .wp = SDMMC_SLOT_NO_WP,
+        .width = 4,
+        .flags = 0,
+    };
+
+    return esp_vfs_fat_sdmmc_mount(BSP_SD_MOUNT_POINT, &host, &slot_config, &mount_config, &bsp_sdcard);
+}
+esp_err_t bsp_sdcard_unmount(void)
+{
+    return esp_vfs_fat_sdcard_unmount(BSP_SD_MOUNT_POINT, bsp_sdcard);
+}
+
+esp_err_t bsp_spiffs_mount(void)
+{
+    esp_vfs_spiffs_conf_t conf = {
+        .base_path = CONFIG_BSP_SPIFFS_MOUNT_POINT,
+        .partition_label = CONFIG_BSP_SPIFFS_PARTITION_LABEL,
+        .max_files = CONFIG_BSP_SPIFFS_MAX_FILES,
+#ifdef CONFIG_BSP_SPIFFS_FORMAT_ON_MOUNT_FAIL
+        .format_if_mount_failed = true,
+#else
+        .format_if_mount_failed = false,
+#endif
+    };
+
+    esp_err_t ret_val = esp_vfs_spiffs_register(&conf);
+
+    BSP_ERROR_CHECK_RETURN_ERR(ret_val);
+
+    size_t total = 0, used = 0;
+    ret_val = esp_spiffs_info(conf.partition_label, &total, &used);
+    if (ret_val != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Failed to get SPIFFS partition information (%s)", esp_err_to_name(ret_val));
+    }
+    else
+    {
+        ESP_LOGI(TAG, "Partition size: total: %d, used: %d", total, used);
+    }
+
+    return ret_val;
+}
+
+esp_err_t bsp_spiffs_unmount(void)
+{
+    return esp_vfs_spiffs_unregister(CONFIG_BSP_SPIFFS_PARTITION_LABEL);
+}
+
+/**************************************************************************************************
+ *
+ * I2S Audio Function
+ *
+ **************************************************************************************************/
+esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config)
+{
+    esp_err_t ret = ESP_FAIL;
+    if (i2s_tx_chan && i2s_rx_chan)
+    {
+        /* Audio was initialized before */
+        return ESP_OK;
+    }
+
+    /* Setup I2S peripheral */
+    i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(CONFIG_BSP_I2S_NUM, I2S_ROLE_MASTER);
+    chan_cfg.auto_clear = true; // Auto clear the legacy data in the DMA buffer
+    BSP_ERROR_CHECK_RETURN_ERR(i2s_new_channel(&chan_cfg, &i2s_tx_chan, &i2s_rx_chan));
+
+    /* Setup I2S channels */
+    const i2s_std_config_t std_cfg_default = BSP_I2S_DUPLEX_MONO_CFG(22050);
+    const i2s_std_config_t *p_i2s_cfg = &std_cfg_default;
+    if (i2s_config != NULL)
+    {
+        p_i2s_cfg = i2s_config;
+    }
+
+    if (i2s_tx_chan != NULL)
+    {
+        ESP_GOTO_ON_ERROR(i2s_channel_init_std_mode(i2s_tx_chan, p_i2s_cfg), err, TAG, "I2S channel initialization failed");
+        ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_tx_chan), err, TAG, "I2S enabling failed");
+    }
+    if (i2s_rx_chan != NULL)
+    {
+        ESP_GOTO_ON_ERROR(i2s_channel_init_std_mode(i2s_rx_chan, p_i2s_cfg), err, TAG, "I2S channel initialization failed");
+        ESP_GOTO_ON_ERROR(i2s_channel_enable(i2s_rx_chan), err, TAG, "I2S enabling failed");
+    }
+
+    audio_codec_i2s_cfg_t i2s_cfg = {
+        .port = CONFIG_BSP_I2S_NUM,
+        .rx_handle = i2s_rx_chan,
+        .tx_handle = i2s_tx_chan,
+    };
+    i2s_data_if = audio_codec_new_i2s_data(&i2s_cfg);
+    BSP_NULL_CHECK_GOTO(i2s_data_if, err);
+
+    return ESP_OK;
+
+err:
+    if (i2s_tx_chan)
+    {
+        i2s_del_channel(i2s_tx_chan);
+    }
+    if (i2s_rx_chan)
+    {
+        i2s_del_channel(i2s_rx_chan);
+    }
+
+    return ret;
+}
+
+esp_codec_dev_handle_t bsp_audio_codec_speaker_init(void)
+{
+    if (i2s_data_if == NULL)
+    {
+        /* Initilize I2C */
+        BSP_ERROR_CHECK_RETURN_NULL(bsp_i2c_init());
+        /* Configure I2S peripheral and Power Amplifier */
+        BSP_ERROR_CHECK_RETURN_NULL(bsp_audio_init(NULL));
+    }
+    assert(i2s_data_if);
+
+    const audio_codec_gpio_if_t *gpio_if = audio_codec_new_gpio();
+
+    audio_codec_i2c_cfg_t i2c_cfg = {
+        .port = BSP_I2C_NUM,
+        .addr = ES8311_CODEC_DEFAULT_ADDR,
+        .bus_handle = i2c_handle,
+    };
+    const audio_codec_ctrl_if_t *i2c_ctrl_if = audio_codec_new_i2c_ctrl(&i2c_cfg);
+    BSP_NULL_CHECK(i2c_ctrl_if, NULL);
+
+    esp_codec_dev_hw_gain_t gain = {
+        .pa_voltage = 5.0,
+        .codec_dac_voltage = 3.3,
+    };
+
+    es8311_codec_cfg_t es8311_cfg = {
+        .ctrl_if = i2c_ctrl_if,
+        .gpio_if = gpio_if,
+        .codec_mode = ESP_CODEC_DEV_WORK_MODE_DAC,
+        .pa_pin = BSP_POWER_AMP_IO,
+        .pa_reverted = false,
+        .master_mode = false,
+        .use_mclk = true,
+        .digital_mic = false,
+        .invert_mclk = false,
+        .invert_sclk = false,
+        .hw_gain = gain,
+    };
+    const audio_codec_if_t *es8311_dev = es8311_codec_new(&es8311_cfg);
+    BSP_NULL_CHECK(es8311_dev, NULL);
+
+    esp_codec_dev_cfg_t codec_dev_cfg = {
+        .dev_type = ESP_CODEC_DEV_TYPE_OUT,
+        .codec_if = es8311_dev,
+        .data_if = i2s_data_if,
+    };
+    return esp_codec_dev_new(&codec_dev_cfg);
+}
+
+esp_codec_dev_handle_t bsp_audio_codec_microphone_init(void)
+{
+    if (i2s_data_if == NULL)
+    {
+        /* Initilize I2C */
+        BSP_ERROR_CHECK_RETURN_NULL(bsp_i2c_init());
+        /* Configure I2S peripheral and Power Amplifier */
+        BSP_ERROR_CHECK_RETURN_NULL(bsp_audio_init(NULL));
+    }
+    assert(i2s_data_if);
+
+    audio_codec_i2c_cfg_t i2c_cfg = {
+        .port = BSP_I2C_NUM,
+        .addr = BSP_ES7210_CODEC_ADDR,
+        .bus_handle = i2c_handle,
+    };
+    const audio_codec_ctrl_if_t *i2c_ctrl_if = audio_codec_new_i2c_ctrl(&i2c_cfg);
+    BSP_NULL_CHECK(i2c_ctrl_if, NULL);
+
+    es7210_codec_cfg_t es7210_cfg = {
+        .ctrl_if = i2c_ctrl_if,
+    };
+    const audio_codec_if_t *es7210_dev = es7210_codec_new(&es7210_cfg);
+    BSP_NULL_CHECK(es7210_dev, NULL);
+
+    esp_codec_dev_cfg_t codec_es7210_dev_cfg = {
+        .dev_type = ESP_CODEC_DEV_TYPE_IN,
+        .codec_if = es7210_dev,
+        .data_if = i2s_data_if,
+    };
+    return esp_codec_dev_new(&codec_es7210_dev_cfg);
+}
+
+// Bit number used to represent command and parameter
+#define LCD_LEDC_CH CONFIG_BSP_DISPLAY_BRIGHTNESS_LEDC_CH
+
+esp_err_t bsp_display_brightness_init(void)
+{
+    const ledc_channel_config_t LCD_backlight_channel = {
+        .gpio_num = BSP_LCD_BACKLIGHT,
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .channel = LCD_LEDC_CH,
+        .intr_type = LEDC_INTR_DISABLE,
+        .timer_sel = 1,
+        .duty = 0,
+        .hpoint = 0,
+        };
+    const ledc_timer_config_t LCD_backlight_timer = {
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .duty_resolution = LEDC_TIMER_10_BIT,
+        .timer_num = 1,
+        .freq_hz = 5000,
+        .clk_cfg = LEDC_AUTO_CLK};
+
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_timer_config(&LCD_backlight_timer));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_channel_config(&LCD_backlight_channel));
+
+    return ESP_OK;
+}
+
+esp_err_t bsp_display_brightness_deinit(void)
+{
+    const ledc_timer_config_t LCD_backlight_timer = {
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .timer_num = 1,
+        .deconfigure = 1
+    };
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_timer_pause(LEDC_LOW_SPEED_MODE, 1));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_timer_config(&LCD_backlight_timer));
+    return ESP_OK;
+}
+
+esp_err_t bsp_display_brightness_set(int brightness_percent)
+{
+    if (brightness_percent > 100)
+    {
+        brightness_percent = 100;
+    }
+    else if (brightness_percent < 0)
+    {
+        brightness_percent = 0;
+    }
+
+    brightness = brightness_percent;
+
+    uint32_t duty_cycle = (1023 * brightness_percent) / 100;
+
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_set_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH, duty_cycle));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_update_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH));
+
+    return ESP_OK;
+}
+
+int bsp_display_brightness_get(void)
+{
+    return brightness;
+}
+
+esp_err_t bsp_display_backlight_off(void)
+{
+    return bsp_display_brightness_set(0);
+}
+
+esp_err_t bsp_display_backlight_on(void)
+{
+    return bsp_display_brightness_set(100);
+}
+
+static esp_err_t bsp_enable_dsi_phy_power(void)
+{
+#if BSP_MIPI_DSI_PHY_PWR_LDO_CHAN > 0
+    // Turn on the power for MIPI DSI PHY, so it can go from "No Power" state to "Shutdown" state
+    static esp_ldo_channel_handle_t phy_pwr_chan = NULL;
+    esp_ldo_channel_config_t ldo_cfg = {
+        .chan_id = BSP_MIPI_DSI_PHY_PWR_LDO_CHAN,
+        .voltage_mv = BSP_MIPI_DSI_PHY_PWR_LDO_VOLTAGE_MV,
+    };
+    ESP_RETURN_ON_ERROR(esp_ldo_acquire_channel(&ldo_cfg, &phy_pwr_chan), TAG, "Acquire LDO channel for DPHY failed");
+    ESP_LOGI(TAG, "MIPI DSI PHY Powered on");
+#endif // BSP_MIPI_DSI_PHY_PWR_LDO_CHAN > 0
+
+    return ESP_OK;
+}
+
+esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io)
+{
+    esp_err_t ret = ESP_OK;
+    bsp_lcd_handles_t handles;
+    ret = bsp_display_new_with_handles(config, &handles);
+
+    *ret_panel = handles.panel;
+    *ret_io = handles.io;
+
+    return ret;
+}
+
+esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_lcd_handles_t *ret_handles)
+{
+    esp_err_t ret = ESP_OK;
+
+    ESP_RETURN_ON_ERROR(bsp_display_brightness_init(), TAG, "Brightness init failed");
+    ESP_RETURN_ON_ERROR(bsp_enable_dsi_phy_power(), TAG, "DSI PHY power failed");
+
+    /* create MIPI DSI bus first, it will initialize the DSI PHY as well */
+    esp_lcd_dsi_bus_handle_t mipi_dsi_bus;
+    esp_lcd_dsi_bus_config_t bus_config = {
+        .bus_id = 0,
+        .num_data_lanes = BSP_LCD_MIPI_DSI_LANE_NUM,
+        .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,
+        .lane_bit_rate_mbps = BSP_LCD_MIPI_DSI_LANE_BITRATE_MBPS,
+    };
+    ESP_RETURN_ON_ERROR(esp_lcd_new_dsi_bus(&bus_config, &mipi_dsi_bus), TAG, "New DSI bus init failed");
+
+    ESP_LOGI(TAG, "Install MIPI DSI LCD control panel");
+    // we use DBI interface to send LCD commands and parameters
+    esp_lcd_panel_io_handle_t io;
+    esp_lcd_dbi_io_config_t dbi_config = {
+        .virtual_channel = 0,
+        .lcd_cmd_bits = 8,
+        .lcd_param_bits = 8,
+    };
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_io_dbi(mipi_dsi_bus, &dbi_config, &io), err, TAG, "New panel IO failed");
+
+    ESP_LOGI(TAG, "Install Waveshare ESP32-P4-WIFI6-Touch-LCD-5 LCD control panel");
+    esp_lcd_dpi_panel_config_t dpi_config = HX8394_720_1280_PANEL_30HZ_DPI_CONFIG(LCD_COLOR_PIXEL_FORMAT_RGB565);
+    dpi_config.num_fbs = CONFIG_BSP_LCD_DPI_BUFFER_NUMS;
+
+    hx8394_vendor_config_t vendor_config = {
+        .mipi_config = {
+            .dsi_bus = mipi_dsi_bus,
+            .dpi_config = &dpi_config,
+            .lane_num = 2,
+        },
+    };
+    esp_lcd_panel_dev_config_t lcd_dev_config = {
+#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
+        .bits_per_pixel = 24,
+#else
+        .bits_per_pixel = 16,
+#endif
+        .rgb_ele_order = BSP_LCD_COLOR_SPACE,
+        .reset_gpio_num = BSP_LCD_RST,
+        .vendor_config = &vendor_config,
+        .flags.reset_active_high = 1,
+    };
+    ESP_GOTO_ON_ERROR(esp_lcd_new_panel_hx8394(io, &lcd_dev_config, &panel_handle), err, TAG, "New LCD panel Waveshare failed");
+    ESP_GOTO_ON_ERROR(esp_lcd_panel_reset(panel_handle), err, TAG, "LCD panel reset failed");
+    ESP_GOTO_ON_ERROR(esp_lcd_panel_init(panel_handle), err, TAG, "LCD panel init failed");
+
+    /* Return all handles */
+    ret_handles->io = io;
+    ret_handles->mipi_dsi_bus = mipi_dsi_bus;
+    ret_handles->panel = panel_handle;
+    ret_handles->control = NULL;
+
+    ESP_LOGI(TAG, "Display initialized");
+
+    return ret;
+
+err:
+    if (panel_handle)
+    {
+        esp_lcd_panel_del(panel_handle);
+    }
+    if (io)
+    {
+        esp_lcd_panel_io_del(io);
+    }
+    if (mipi_dsi_bus)
+    {
+        esp_lcd_del_dsi_bus(mipi_dsi_bus);
+    }
+    return ret;
+}
+
+esp_err_t bsp_touch_new(const bsp_display_cfg_t *cfg, esp_lcd_touch_handle_t *ret_touch)
+{
+    assert(cfg != NULL);
+
+    /* Initilize I2C */
+    BSP_ERROR_CHECK_RETURN_ERR(bsp_i2c_init());
+
+    /* Initialize touch */
+    const esp_lcd_touch_config_t tp_cfg = {
+        .x_max = BSP_LCD_H_RES,
+        .y_max = BSP_LCD_V_RES,
+        .rst_gpio_num = BSP_LCD_TOUCH_RST, // Shared with LCD reset
+        .int_gpio_num = BSP_LCD_TOUCH_INT,
+        .levels = {
+            .reset = 0,
+            .interrupt = 0,
+        },
+        .flags = {
+            .swap_xy = cfg->touch_flags.swap_xy,
+            .mirror_x = cfg->touch_flags.mirror_x,
+            .mirror_y = cfg->touch_flags.mirror_y,
+        },
+    };
+    esp_lcd_panel_io_handle_t tp_io_handle = NULL;
+    esp_lcd_panel_io_i2c_config_t tp_io_config;
+    if (ESP_OK == bsp_i2c_device_probe(ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS))
+    {
+        ESP_LOGI(TAG, "Touch 0x5d found");
+        esp_lcd_panel_io_i2c_config_t config = ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG();
+        memcpy(&tp_io_config, &config, sizeof(config));
+    }
+    else if (ESP_OK == bsp_i2c_device_probe(ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP))
+    {
+        ESP_LOGI(TAG, "Touch 0x14 found");
+        esp_lcd_panel_io_i2c_config_t config = ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG();
+        config.dev_addr = ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP;
+        memcpy(&tp_io_config, &config, sizeof(config));
+    }
+    else
+    {
+        ESP_LOGE(TAG, "Touch not found");
+        return ESP_ERR_NOT_FOUND;
+    }
+    tp_io_config.scl_speed_hz = CONFIG_BSP_I2C_CLK_SPEED_HZ;
+    ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c(i2c_handle, &tp_io_config, &tp_io_handle), TAG, "");
+    return esp_lcd_touch_new_i2c_gt911(tp_io_handle, &tp_cfg, ret_touch);
+}
+
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
+{
+    assert(cfg != NULL);
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_new(NULL, &panel_handle, &io_handle));
+
+    /* Add LCD screen */
+    ESP_LOGD(TAG, "Add LCD screen");
+    esp_lv_adapter_display_config_t disp_cfg = {
+        .panel = panel_handle,
+        .panel_io = io_handle,
+        .profile = {
+            .interface = ESP_LV_ADAPTER_PANEL_IF_MIPI_DSI,
+            .rotation = cfg->rotation,
+            .hor_res = BSP_LCD_H_RES,
+            .ver_res = BSP_LCD_V_RES,
+            .buffer_height = 50,
+            .use_psram = false,
+            .enable_ppa_accel = false,
+            .require_double_buffer = false,
+        },
+        .tear_avoid_mode = cfg->tear_avoid_mode,
+    };
+
+    lv_display_t *disp = esp_lv_adapter_register_display(&disp_cfg);
+    if (!disp)
+    {
+        return NULL;
+    }
+
+    return disp;
+}
+
+static lv_indev_t *bsp_display_indev_init(const bsp_display_cfg_t *cfg, lv_display_t *disp)
+{
+    assert(cfg != NULL);
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_touch_new(cfg, &tp));
+    assert(tp);
+
+    /* Add touch input (for selected screen) */
+    const esp_lv_adapter_touch_config_t touch_cfg = ESP_LV_ADAPTER_TOUCH_DEFAULT_CONFIG(disp, tp);
+
+    return esp_lv_adapter_register_touch(&touch_cfg);
+}
+
+lv_display_t *bsp_display_start(void)
+{
+    bsp_display_cfg_t cfg = {
+        .lv_adapter_cfg = ESP_LV_ADAPTER_DEFAULT_CONFIG(),
+        .rotation = ESP_LV_ADAPTER_ROTATE_0,
+        .tear_avoid_mode = ESP_LV_ADAPTER_TEAR_AVOID_MODE_TRIPLE_PARTIAL,
+        .touch_flags = {
+            .swap_xy = 0,
+            .mirror_x = 0,
+            .mirror_y = 0}};
+    return bsp_display_start_with_config(&cfg);
+}
+
+lv_display_t *bsp_display_start_with_config(bsp_display_cfg_t *cfg)
+{
+    lv_display_t *disp;
+
+    assert(cfg != NULL);
+    BSP_ERROR_CHECK_RETURN_NULL(esp_lv_adapter_init(&cfg->lv_adapter_cfg));
+
+    BSP_ERROR_CHECK_RETURN_NULL(bsp_display_brightness_init());
+
+    BSP_NULL_CHECK(disp = bsp_display_lcd_init(cfg), NULL);
+
+    BSP_NULL_CHECK(disp_indev = bsp_display_indev_init(cfg, disp), NULL);
+
+    ESP_ERROR_CHECK(esp_lv_adapter_start());
+
+    return disp;
+}
+
+lv_indev_t *bsp_display_get_input_dev(void)
+{
+    return disp_indev;
+}
+
+void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+{
+    lv_disp_set_rotation(disp, rotation);
+}
+
+bool bsp_display_lock(uint32_t timeout_ms)
+{
+    return esp_lv_adapter_lock(timeout_ms);
+}
+
+void bsp_display_unlock(void)
+{
+    esp_lv_adapter_unlock();
+}
+
+esp_lcd_panel_handle_t bsp_display_get_panel_handle(void)
+{
+    return panel_handle;
+}
+
+#endif // (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+
+static void usb_lib_task(void *arg)
+{
+    while (1)
+    {
+        // Start handling system events
+        uint32_t event_flags;
+        usb_host_lib_handle_events(portMAX_DELAY, &event_flags);
+        if (event_flags & USB_HOST_LIB_EVENT_FLAGS_NO_CLIENTS)
+        {
+            ESP_ERROR_CHECK(usb_host_device_free_all());
+        }
+        if (event_flags & USB_HOST_LIB_EVENT_FLAGS_ALL_FREE)
+        {
+            ESP_LOGI(TAG, "USB: All devices freed");
+        }
+    }
+}
+
+esp_err_t bsp_usb_host_start(bsp_usb_host_power_mode_t mode, bool limit_500mA)
+{
+    // Install USB Host driver. Should only be called once in entire application
+    ESP_LOGI(TAG, "Installing USB Host");
+    const usb_host_config_t host_config = {
+        .skip_phy_setup = false,
+        .intr_flags = ESP_INTR_FLAG_LEVEL1,
+    };
+    BSP_ERROR_CHECK_RETURN_ERR(usb_host_install(&host_config));
+
+    // Create a task that will handle USB library events
+    if (xTaskCreate(usb_lib_task, "usb_lib", 4096, NULL, 10, &usb_host_task) != pdTRUE)
+    {
+        ESP_LOGE(TAG, "Creating USB host lib task failed");
+        abort();
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t bsp_usb_host_stop(void)
+{
+    usb_host_uninstall();
+    if (usb_host_task)
+    {
+        vTaskSuspend(usb_host_task);
+        vTaskDelete(usb_host_task);
+    }
+    return ESP_OK;
+}

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/esp32_p4_wifi6_touch_lcd_5.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/esp32_p4_wifi6_touch_lcd_5.c
@@ -568,7 +568,7 @@ static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
             .hor_res = BSP_LCD_H_RES,
             .ver_res = BSP_LCD_V_RES,
             .buffer_height = 50,
-            .use_psram = false,
+            .use_psram = CONFIG_BSP_DISPLAY_LVGL_USE_PSRAM,
             .enable_ppa_accel = false,
             .require_double_buffer = false,
         },

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/idf_component.yml
@@ -1,0 +1,28 @@
+dependencies:
+  espressif/usb:
+    version: "^1.4.1"
+    rules:
+      - if: "idf_version >= 6.0"
+  esp_codec_dev:
+    public: true
+    version: "~1.5"
+  esp_lcd_touch_gt911: ^1
+  espressif/esp_lvgl_adapter:
+    public: true
+    version: "~0.6"
+    pre_release: true
+  idf: '>=5.4'
+  lvgl/lvgl:
+    public: true
+    version: '9.5.0'
+  # v2.1.0 adds an opt-out for the driver's board-specific I2C sequence.
+  # This BSP owns the corresponding board-level I2C and power behavior.
+  waveshare/esp_lcd_hx8394: '^2.1.0'
+description: Based on ESP32-P4 chip, waveshare electronics designed a 5-inch screen, highly integrated development board
+repository: https://github.com/waveshareteam/Waveshare-ESP32-components.git
+tags:
+- bsp
+targets:
+- esp32p4
+url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-5.htm
+version: 1.0.1

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/idf_component.yml
@@ -27,4 +27,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-5.htm
-version: 1.0.1
+version: 1.0.2

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/idf_component.yml
@@ -15,9 +15,11 @@ dependencies:
   lvgl/lvgl:
     public: true
     version: '9.5.0'
-  # v2.1.0 adds an opt-out for the driver's board-specific I2C sequence.
-  # This BSP owns the corresponding board-level I2C and power behavior.
-  waveshare/esp_lcd_hx8394: '^2.1.0'
+  # Temporary immutable PR/HIL validation pin until 2.1.0 is published to the registry.
+  waveshare/esp_lcd_hx8394:
+    git: https://github.com/waveshareteam/Waveshare-ESP32-components.git
+    path: display/lcd/esp_lcd_hx8394
+    version: fc6e6d2d63aa314cdcec2e8912614aacff2fbd6d
 description: Based on ESP32-P4 chip, waveshare electronics designed a 5-inch screen, highly integrated development board
 repository: https://github.com/waveshareteam/Waveshare-ESP32-components.git
 tags:

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/config.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/config.h
@@ -1,0 +1,10 @@
+#pragma once
+
+/**************************************************************************************************
+ * BSP configuration
+ **************************************************************************************************/
+// By default, this BSP is shipped with LVGL graphical library. Enabling this option will exclude it.
+// If you want to use BSP without LVGL, select BSP version with 'noglib' suffix.
+#if !defined(BSP_CONFIG_NO_GRAPHIC_LIB) // Check if the symbol is not coming from compiler definitions (-D...)
+#define BSP_CONFIG_NO_GRAPHIC_LIB (0)
+#endif

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/display.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/display.h
@@ -1,0 +1,160 @@
+#pragma once
+#include "esp_lcd_types.h"
+#include "esp_lcd_mipi_dsi.h"
+#include "esp_idf_version.h"
+#include "sdkconfig.h"
+
+/* LCD color formats */
+#define ESP_LCD_COLOR_FORMAT_RGB565    (1)
+#define ESP_LCD_COLOR_FORMAT_RGB888    (2)
+
+/* LCD display color format */
+#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB888)
+#else
+#define BSP_LCD_COLOR_FORMAT        (ESP_LCD_COLOR_FORMAT_RGB565)
+#endif
+/* LCD display color bytes endianess */
+#define BSP_LCD_BIGENDIAN           (0)
+/* LCD display color bits */
+#define BSP_LCD_BITS_PER_PIXEL      (16)
+/* LCD display color space */
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
+#else
+#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#endif
+
+#define BSP_LCD_H_RES              (720)
+#define BSP_LCD_V_RES              (1280)
+#define BSP_LCD_MIPI_DSI_LANE_BITRATE_MBPS (700)
+
+#define BSP_LCD_MIPI_DSI_LANE_NUM          (2)    // 2 data lanes
+#define BSP_MIPI_DSI_PHY_PWR_LDO_CHAN       (3)  // LDO_VO3 is connected to VDD_MIPI_DPHY
+#define BSP_MIPI_DSI_PHY_PWR_LDO_VOLTAGE_MV (2500)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief BSP display configuration structure
+ *
+ */
+typedef struct {
+    int dummy;
+} bsp_display_config_t;
+
+/**
+ * @brief BSP display return handles
+ *
+ */
+typedef struct {
+    esp_lcd_dsi_bus_handle_t    mipi_dsi_bus;  /*!< MIPI DSI bus handle */
+    esp_lcd_panel_io_handle_t   io;            /*!< ESP LCD IO handle */
+    esp_lcd_panel_handle_t      panel;         /*!< ESP LCD panel (color) handle */
+    esp_lcd_panel_handle_t      control;       /*!< ESP LCD panel (control) handle */
+} bsp_lcd_handles_t;
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_io_del(io);
+ * esp_lcd_del_dsi_bus(mipi_dsi_bus);
+ * \endcode
+ *
+ * @param[in]  config    display configuration
+ * @param[out] ret_panel esp_lcd panel handle
+ * @param[out] ret_io    esp_lcd IO handle
+ * @return
+ *      - ESP_OK         On success
+ *      - Else           esp_lcd failure
+ */
+esp_err_t bsp_display_new(const bsp_display_config_t *config, esp_lcd_panel_handle_t *ret_panel, esp_lcd_panel_io_handle_t *ret_io);
+
+/**
+ * @brief Create new display panel
+ *
+ * For maximum flexibility, this function performs only reset and initialization of the display.
+ * You must turn on the display explicitly by calling esp_lcd_panel_disp_on_off().
+ * The display's backlight is not turned on either. You can use bsp_display_backlight_on/off(),
+ * bsp_display_brightness_set() (on supported boards) or implement your own backlight control.
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_panel_del(panel);
+ * esp_lcd_panel_del(control);
+ * esp_lcd_panel_io_del(io);
+ * esp_lcd_del_dsi_bus(mipi_dsi_bus);
+ * \endcode
+ *
+ * @param[in]  config    display configuration
+ * @param[out] ret_handles all esp_lcd handles in one structure
+ * @return
+ *      - ESP_OK         On success
+ *      - Else           esp_lcd failure
+ */
+esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_lcd_handles_t *ret_handles);
+
+/**
+ * @brief Initialize display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_init(void);
+
+/**
+ * @brief Set display's brightness
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Brightness must be already initialized by calling bsp_display_brightness_init() or bsp_display_new()
+ *
+ * @param[in] brightness_percent Brightness in [%]
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_brightness_set(int brightness_percent);
+
+int bsp_display_brightness_get(void);
+/**
+ * @brief Turn on display backlight
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Brightness must be already initialized by calling bsp_display_brightness_init() or bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_on(void);
+
+/**
+ * @brief Turn off display backlight
+ *
+ * Brightness is controlled with PWM signal to a pin controlling backlight.
+ * Brightness must be already initialized by calling bsp_display_brightness_init() or bsp_display_new()
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   Parameter error
+ */
+esp_err_t bsp_display_backlight_off(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/esp-bsp.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/esp-bsp.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "bsp/esp32_p4_wifi6_touch_lcd_5.h"

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/esp32_p4_wifi6_touch_lcd_5.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/esp32_p4_wifi6_touch_lcd_5.h
@@ -1,0 +1,348 @@
+#pragma once
+
+#include "sdkconfig.h"
+#include "driver/gpio.h"
+#include "driver/i2c_master.h"
+#include "driver/sdmmc_host.h"
+#include "driver/i2s_std.h"
+#include "bsp/config.h"
+#include "bsp/display.h"
+#include "esp_codec_dev.h"
+#include "sdkconfig.h"
+
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+#include "lvgl.h"
+#include "esp_lv_adapter.h"
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
+
+/**************************************************************************************************
+ *  BSP Capabilities
+ **************************************************************************************************/
+
+#define BSP_CAPS_DISPLAY        1
+#define BSP_CAPS_TOUCH          1
+#define BSP_CAPS_BUTTONS        0
+#define BSP_CAPS_AUDIO          1
+#define BSP_CAPS_AUDIO_SPEAKER  1
+#define BSP_CAPS_AUDIO_MIC      1
+#define BSP_CAPS_SDCARD         1
+#define BSP_CAPS_IMU            0
+
+/**************************************************************************************************
+ *  ESP-BOX pinout
+ **************************************************************************************************/
+/* I2C */
+#define BSP_I2C_SCL           (GPIO_NUM_8)
+#define BSP_I2C_SDA           (GPIO_NUM_7)
+
+/* Audio */
+#define BSP_I2S_SCLK          (GPIO_NUM_12)
+#define BSP_I2S_MCLK          (GPIO_NUM_13)
+#define BSP_I2S_LCLK          (GPIO_NUM_10)
+#define BSP_I2S_DOUT          (GPIO_NUM_9)
+#define BSP_I2S_DSIN          (GPIO_NUM_11)
+#define BSP_POWER_AMP_IO      (GPIO_NUM_53)
+
+#define BSP_LCD_BACKLIGHT     (GPIO_NUM_26)
+#define BSP_LCD_RST           (GPIO_NUM_27)
+#define BSP_LCD_TOUCH_RST     (GPIO_NUM_NC)
+#define BSP_LCD_TOUCH_INT     (GPIO_NUM_NC)
+
+/* uSD card */
+#define BSP_SD_D0             (GPIO_NUM_39)
+#define BSP_SD_D1             (GPIO_NUM_40)
+#define BSP_SD_D2             (GPIO_NUM_41)
+#define BSP_SD_D3             (GPIO_NUM_42)
+#define BSP_SD_CMD            (GPIO_NUM_44)
+#define BSP_SD_CLK            (GPIO_NUM_43)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**************************************************************************************************
+ *
+ * I2C interface
+ *
+ * There are multiple devices connected to I2C peripheral:
+ *  - Codec ES8311 (configuration only)
+ *  - LCD Touch controller
+ **************************************************************************************************/
+#define BSP_I2C_NUM     CONFIG_BSP_I2C_NUM
+
+/**
+ * @brief Init I2C driver
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   I2C parameter error
+ *      - ESP_FAIL              I2C driver installation error
+ *
+ */
+esp_err_t bsp_i2c_init(void);
+
+/**
+ * @brief Deinit I2C driver and free its resources
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   I2C parameter error
+ *
+ */
+esp_err_t bsp_i2c_deinit(void);
+
+/**
+ * @brief Get I2C driver handle
+ *
+ * @return
+ *      - I2C handle
+ *
+ */
+i2c_master_bus_handle_t bsp_i2c_get_handle(void);
+
+/**************************************************************************************************
+ *
+ * I2S audio interface
+ *
+ * There are two devices connected to the I2S peripheral:
+ *  - Codec ES8311 for output(playback) and input(recording) path
+ *
+ * For speaker initialization use bsp_audio_codec_speaker_init() which is inside initialize I2S with bsp_audio_init().
+ * For microphone initialization use bsp_audio_codec_microphone_init() which is inside initialize I2S with bsp_audio_init().
+ * After speaker or microphone initialization, use functions from esp_codec_dev for play/record audio.
+ * Example audio play:
+ * \code{.c}
+ * esp_codec_dev_set_out_vol(spk_codec_dev, DEFAULT_VOLUME);
+ * esp_codec_dev_open(spk_codec_dev, &fs);
+ * esp_codec_dev_write(spk_codec_dev, wav_bytes, bytes_read_from_spiffs);
+ * esp_codec_dev_close(spk_codec_dev);
+ * \endcode
+ **************************************************************************************************/
+
+/**
+ * @brief Init audio
+ *
+ * @note There is no deinit audio function. Users can free audio resources by calling i2s_del_channel()
+ * @warning The type of i2s_config param is depending on IDF version.
+ * @param[in]  i2s_config I2S configuration. Pass NULL to use default values (Mono, duplex, 16bit, 22050 Hz)
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_NOT_SUPPORTED The communication mode is not supported on the current chip
+ *      - ESP_ERR_INVALID_ARG   NULL pointer or invalid configuration
+ *      - ESP_ERR_NOT_FOUND     No available I2S channel found
+ *      - ESP_ERR_NO_MEM        No memory for storing the channel information
+ *      - ESP_ERR_INVALID_STATE This channel has not initialized or already started
+ */
+esp_err_t bsp_audio_init(const i2s_std_config_t *i2s_config);
+
+/**
+ * @brief Initialize speaker codec device
+ *
+ * @return Pointer to codec device handle or NULL when error occurred
+ */
+esp_codec_dev_handle_t bsp_audio_codec_speaker_init(void);
+
+/**
+ * @brief Initialize microphone codec device
+ *
+ * @return Pointer to codec device handle or NULL when error occurred
+ */
+esp_codec_dev_handle_t bsp_audio_codec_microphone_init(void);
+
+/**************************************************************************************************
+ *
+ * SPIFFS
+ *
+ * After mounting the SPIFFS, it can be accessed with stdio functions ie.:
+ * \code{.c}
+ * FILE* f = fopen(BSP_SPIFFS_MOUNT_POINT"/hello.txt", "w");
+ * fprintf(f, "Hello World!\n");
+ * fclose(f);
+ * \endcode
+ **************************************************************************************************/
+#define BSP_SPIFFS_MOUNT_POINT      CONFIG_BSP_SPIFFS_MOUNT_POINT
+
+/**
+ * @brief Mount SPIFFS to virtual file system
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_STATE if esp_vfs_spiffs_register was already called
+ *      - ESP_ERR_NO_MEM if memory can not be allocated
+ *      - ESP_FAIL if partition can not be mounted
+ *      - other error codes
+ */
+esp_err_t bsp_spiffs_mount(void);
+
+/**
+ * @brief Unmount SPIFFS from virtual file system
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_NOT_FOUND if the partition table does not contain SPIFFS partition with given label
+ *      - ESP_ERR_INVALID_STATE if esp_vfs_spiffs_unregister was already called
+ *      - ESP_ERR_NO_MEM if memory can not be allocated
+ *      - ESP_FAIL if partition can not be mounted
+ *      - other error codes
+ */
+esp_err_t bsp_spiffs_unmount(void);
+
+/**************************************************************************************************
+ *
+ * uSD card
+ *
+ * After mounting the uSD card, it can be accessed with stdio functions ie.:
+ * \code{.c}
+ * FILE* f = fopen(BSP_MOUNT_POINT"/hello.txt", "w");
+ * fprintf(f, "Hello %s!\n", bsp_sdcard->cid.name);
+ * fclose(f);
+ * \endcode
+ **************************************************************************************************/
+#define BSP_SD_MOUNT_POINT      CONFIG_BSP_SD_MOUNT_POINT
+extern sdmmc_card_t *bsp_sdcard;
+
+/**
+ * @brief Mount microSD card to virtual file system
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_sdmmc_mount was already called
+ *      - ESP_ERR_NO_MEM if memory cannot be allocated
+ *      - ESP_FAIL if partition cannot be mounted
+ *      - other error codes from SDMMC or SPI drivers, SDMMC protocol, or FATFS drivers
+ */
+esp_err_t bsp_sdcard_mount(void);
+
+/**
+ * @brief Unmount microSD card from virtual file system
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_NOT_FOUND if the partition table does not contain FATFS partition with given label
+ *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_spiflash_mount was already called
+ *      - ESP_ERR_NO_MEM if memory can not be allocated
+ *      - ESP_FAIL if partition can not be mounted
+ *      - other error codes from wear levelling library, SPI flash driver, or FATFS drivers
+ */
+esp_err_t bsp_sdcard_unmount(void);
+
+/**************************************************************************************************
+ *
+ * LCD interface
+ *
+ * ESP-BOX is shipped with 2.4inch ST7789 display controller.
+ * It features 16-bit colors, 320x240 resolution and capacitive touch controller.
+ *
+ * LVGL is used as graphics library. LVGL is NOT thread safe, therefore the user must take LVGL mutex
+ * by calling bsp_display_lock() before calling and LVGL API (lv_...) and then give the mutex with
+ * bsp_display_unlock().
+ *
+ * Display's backlight must be enabled explicitly by calling bsp_display_backlight_on()
+ **************************************************************************************************/
+#define BSP_LCD_PIXEL_CLOCK_MHZ     (80)
+
+#if (BSP_CONFIG_NO_GRAPHIC_LIB == 0)
+
+#define BSP_LCD_DRAW_BUFF_SIZE     (BSP_LCD_H_RES * 50) // Frame buffer size in pixels
+#define BSP_LCD_DRAW_BUFF_DOUBLE   (0)
+
+/**
+ * @brief BSP display configuration structure
+ *
+ */
+typedef struct {
+    esp_lv_adapter_config_t          lv_adapter_cfg;
+    esp_lv_adapter_rotation_t        rotation;
+    esp_lv_adapter_tear_avoid_mode_t tear_avoid_mode;
+    struct {
+        unsigned int swap_xy;  /*!< Swap X and Y after read coordinates */
+        unsigned int mirror_x; /*!< Mirror X after read coordinates */
+        unsigned int mirror_y; /*!< Mirror Y after read coordinates */
+    } touch_flags;
+} bsp_display_cfg_t;
+
+/**
+ * @brief Initialize display
+ *
+ * This function initializes SPI, display controller and starts LVGL handling task.
+ * LCD backlight must be enabled separately by calling bsp_display_brightness_set()
+ *
+ * @return Pointer to LVGL display or NULL when error occured
+ */
+lv_display_t *bsp_display_start(void);
+
+/**
+ * @brief Initialize display
+ *
+ * This function initializes SPI, display controller and starts LVGL handling task.
+ * LCD backlight must be enabled separately by calling bsp_display_brightness_set()
+ *
+ * @param cfg display configuration
+ *
+ * @return Pointer to LVGL display or NULL when error occured
+ */
+lv_display_t *bsp_display_start_with_config(bsp_display_cfg_t *cfg);
+
+/**
+ * @brief Get pointer to input device (touch, buttons, ...)
+ *
+ * @note The LVGL input device is initialized in bsp_display_start() function.
+ *
+ * @return Pointer to LVGL input device or NULL when not initialized
+ */
+lv_indev_t *bsp_display_get_input_dev(void);
+
+bool bsp_display_lock(uint32_t timeout_ms);
+
+/**
+ * @brief Give LVGL mutex
+ *
+ */
+void bsp_display_unlock(void);
+esp_lcd_panel_handle_t bsp_display_get_panel_handle(void);
+
+#endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
+
+/**************************************************************************************************
+ *
+ * USB
+ *
+ **************************************************************************************************/
+
+
+/**
+ * @brief Power modes of USB Host connector
+ */
+typedef enum bsp_usb_host_power_mode_t {
+    BSP_USB_HOST_POWER_MODE_USB_DEV, //!< Power from USB DEV port
+} bsp_usb_host_power_mode_t;
+
+/**
+ * @brief Start USB host
+ *
+ * This is a one-stop-shop function that will configure the board for USB Host mode
+ * and start USB Host library
+ *
+ * @param[in] mode        USB Host connector power mode (Not used on this board)
+ * @param[in] limit_500mA Limit output current to 500mA (Not used on this board)
+ * @return
+ *     - ESP_OK                 On success
+ *     - ESP_ERR_INVALID_ARG    Parameter error
+ *     - ESP_ERR_NO_MEM         Memory cannot be allocated
+ */
+esp_err_t bsp_usb_host_start(bsp_usb_host_power_mode_t mode, bool limit_500mA);
+
+/**
+ * @brief Stop USB host
+ *
+ * USB Host lib will be uninstalled and power from connector removed.
+ *
+ * @return
+ *     - ESP_OK              On success
+ *     - ESP_ERR_INVALID_ARG Parameter error
+ */
+esp_err_t bsp_usb_host_stop(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/touch.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/include/bsp/touch.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "esp_lcd_touch.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Create new touchscreen
+ *
+ * If you want to free resources allocated by this function, you can use esp_lcd_touch API, ie.:
+ *
+ * \code{.c}
+ * esp_lcd_touch_del(tp);
+ * \endcode
+ *
+ * @param[in]  config    touch configuration
+ * @param[out] ret_touch esp_lcd_touch touchscreen handle
+ * @return
+ *      - ESP_OK         On success
+ *      - Else           esp_lcd_touch failure
+ */
+esp_err_t bsp_touch_new(const bsp_display_cfg_t *cfg, esp_lcd_touch_handle_t *ret_touch);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/priv_include/bsp_err_check.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/priv_include/bsp_err_check.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "esp_check.h"
+#include "sdkconfig.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Assert on error, if selected in menuconfig. Otherwise return error code. */
+#if CONFIG_BSP_ERROR_CHECK
+#define BSP_ERROR_CHECK_RETURN_ERR(x)    ESP_ERROR_CHECK(x)
+#define BSP_ERROR_CHECK_RETURN_NULL(x)   ESP_ERROR_CHECK(x)
+#define BSP_ERROR_CHECK(x, ret)          ESP_ERROR_CHECK(x)
+#define BSP_NULL_CHECK(x, ret)           assert(x)
+#define BSP_NULL_CHECK_GOTO(x, goto_tag) assert(x)
+#else
+#define BSP_ERROR_CHECK_RETURN_ERR(x) do { \
+        esp_err_t err_rc_ = (x);            \
+        if (unlikely(err_rc_ != ESP_OK)) {  \
+            return err_rc_;                 \
+        }                                   \
+    } while(0)
+
+#define BSP_ERROR_CHECK_RETURN_NULL(x)  do { \
+        if (unlikely((x) != ESP_OK)) {      \
+            return NULL;                    \
+        }                                   \
+    } while(0)
+
+#define BSP_NULL_CHECK(x, ret) do { \
+        if ((x) == NULL) {          \
+            return ret;             \
+        }                           \
+    } while(0)
+
+#define BSP_ERROR_CHECK(x, ret)      do { \
+        if (unlikely((x) != ESP_OK)) {    \
+            return ret;                   \
+        }                                 \
+    } while(0)
+
+#define BSP_NULL_CHECK_GOTO(x, goto_tag) do { \
+        if ((x) == NULL) {      \
+            goto goto_tag;      \
+        }                       \
+    } while(0)
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/display/lcd/esp_lcd_hx8394/Kconfig
+++ b/display/lcd/esp_lcd_hx8394/Kconfig
@@ -1,0 +1,12 @@
+menu "ESP LCD HX8394 configuration"
+
+    config ESP_LCD_HX8394_SKIP_I2C_INIT
+        bool "Skip board-specific I2C initialization"
+        default n
+        help
+            Skip the board-specific I2C bus setup and register sequence in the
+            HX8394 panel constructor. Leave this disabled for backward-compatible
+            standalone driver behavior. Enable it when the board BSP owns the
+            required board-level I2C and power initialization.
+
+endmenu

--- a/display/lcd/esp_lcd_hx8394/README.md
+++ b/display/lcd/esp_lcd_hx8394/README.md
@@ -10,6 +10,14 @@ Implementation of the HX8394 LCD controller with esp_lcd component.
 
 **Note**: MIPI-DSI interface only supports ESP-IDF v5.3 and above versions.
 
+## Board-specific I2C initialization
+
+`ESP_LCD_HX8394_SKIP_I2C_INIT` defaults to `n`, so the driver preserves its
+existing board-specific I2C setup, register writes, delays, and device cleanup.
+Set it to `y` only when a board BSP owns that board-level I2C and power behavior.
+The ESP32-P4-WIFI6-Touch-LCD-5 BSP enables the opt-out; standalone users retain
+the backward-compatible default.
+
 ## Add to project
 
 Packages from this repository are uploaded to [Espressif's component service](https://components.espressif.com/).

--- a/display/lcd/esp_lcd_hx8394/esp_lcd_hx8394.c
+++ b/display/lcd/esp_lcd_hx8394/esp_lcd_hx8394.c
@@ -14,6 +14,12 @@
 #include "esp_lcd_hx8394.h"
 #include "esp_idf_version.h"
 #include "i2c_bus.h"
+#include "sdkconfig.h"
+
+/* Keep the default when this source is built without a generated Kconfig header. */
+#ifndef CONFIG_ESP_LCD_HX8394_SKIP_I2C_INIT
+#define CONFIG_ESP_LCD_HX8394_SKIP_I2C_INIT 0
+#endif
 
 #define HX8394_CMD_DSI_INT0 (0xBA)
 #define HX8394_DSI_1_LANE (0x60)
@@ -106,6 +112,8 @@ esp_err_t esp_lcd_new_panel_hx8394(const esp_lcd_panel_io_handle_t io, const esp
     hx8394->reset_gpio_num = panel_dev_config->reset_gpio_num;
     hx8394->flags.reset_level = panel_dev_config->flags.reset_active_high;
 
+    /* Standalone compatibility: preserve the existing board-specific sequence unless opted out. */
+#if !CONFIG_ESP_LCD_HX8394_SKIP_I2C_INIT
     i2c_config_t conf = {
         .mode = I2C_MODE_MASTER,
         .sda_io_num = 7,
@@ -132,6 +140,7 @@ esp_err_t esp_lcd_new_panel_hx8394(const esp_lcd_panel_io_handle_t io, const esp
     // i2c_bus_delete(&i2c0_bus);
 
     vTaskDelay(pdMS_TO_TICKS(1000));
+#endif // !CONFIG_ESP_LCD_HX8394_SKIP_I2C_INIT
 
     // Create MIPI DPI panel
     esp_lcd_panel_handle_t panel_handle = NULL;

--- a/display/lcd/esp_lcd_hx8394/idf_component.yml
+++ b/display/lcd/esp_lcd_hx8394/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.1.0"
 license: "MIT"
 targets:
   - esp32p4


### PR DESCRIPTION
## Summary

- Add the managed LCD5 BSP.
- HX8394 default behavior executes the existing I2C initialization sequence.
- CONFIG_ESP_LCD_HX8394_SKIP_I2C_INIT is an explicit opt-out.
- The LCD5 BSP selects the opt-out.
- The HX8394 source is pinned immutably at fc6e6d2d63aa314cdcec2e8912614aacff2fbd6d for validation.

## Validation

- Final head: d9a93c0cf44bc8c39eced92462297262dd93d645.
- GitHub Actions run: [31559649085](https://github.com/waveshareteam/Waveshare-ESP32-components/actions/runs/31559649085) — 104/104 checks succeeded.
- manifest-check, LCD5 BSP IDF5.5.5/6.0.2, HX IDF5.5.5/6.0.2, and ci-gate all succeeded.
- Static manifest, YAML, contract, and diff checks passed.
- No local product build was run; Actions provides the build evidence.

## Hardware boundary

- User real-board HIL is required before merge, registry release, or a product registry switch.
- Compile success does not prove display, touch, audio, storage, USB, or board power behavior.
- PCB, electrical, and revision compatibility remain unverified.