### PR TITLE
feat: add configurable P4 display control and LVGL 8/9 compatibility

### DIFF
--- a/bsp/esp32_p4_platform/Kconfig
+++ b/bsp/esp32_p4_platform/Kconfig
@@ -77,6 +77,27 @@ menu "Board Support Package(ESP32-P4)"
     endmenu
 
     menu "Display"
+        config BSP_LCD_BACKLIGHT
+            int "LCD backlight GPIO"
+            default -1
+            help
+                GPIO number used to control the LCD backlight.
+                Set to -1 when the signal is not connected.
+
+        config BSP_LCD_RST
+            int "LCD reset GPIO"
+            default -1
+            help
+                GPIO number used to reset the LCD.
+                Set to -1 when the signal is not connected.
+
+        config BSP_LCD_TOUCH_RST
+            int "LCD touch reset GPIO"
+            default -1
+            help
+                GPIO number used to reset the LCD touch controller.
+                Set to -1 when the signal is not connected.
+
         config BSP_LCD_DPI_BUFFER_NUMS
             int "Set number of frame buffers"
             default 3

--- a/bsp/esp32_p4_platform/esp32_p4_platform.c
+++ b/bsp/esp32_p4_platform/esp32_p4_platform.c
@@ -30,7 +30,9 @@
 #include "bsp/esp32_p4_platform.h"
 #include "bsp/display.h"
 #include "bsp/touch.h"
+
 #include "esp_lcd_touch_gt911.h"
+
 #include "bsp_err_check.h"
 #include "esp_codec_dev_defaults.h"
 
@@ -436,7 +438,30 @@ esp_codec_dev_handle_t bsp_audio_codec_microphone_init(void)
 
 esp_err_t bsp_display_brightness_init(void)
 {
-    bsp_i2c_init();
+#if BSP_LCD_BACKLIGHT != -1
+    const ledc_channel_config_t lcd_backlight_channel = {
+        .gpio_num = BSP_LCD_BACKLIGHT,
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .channel = LCD_LEDC_CH,
+        .intr_type = LEDC_INTR_DISABLE,
+        .timer_sel = LEDC_TIMER_1,
+        .duty = 0,
+        .hpoint = 0,
+    };
+    const ledc_timer_config_t lcd_backlight_timer = {
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .duty_resolution = LEDC_TIMER_10_BIT,
+        .timer_num = LEDC_TIMER_1,
+        .freq_hz = 5000,
+        .clk_cfg = LEDC_AUTO_CLK,
+    };
+
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_timer_config(&lcd_backlight_timer));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_channel_config(&lcd_backlight_channel));
+#else
+    BSP_ERROR_CHECK_RETURN_ERR(bsp_i2c_init());
+#endif
+
     return ESP_OK;
 }
 
@@ -451,6 +476,11 @@ esp_err_t bsp_display_brightness_set(int brightness_percent)
         brightness_percent = 0;
     }
 
+#if BSP_LCD_BACKLIGHT != -1
+    uint32_t duty_cycle = (1023 * brightness_percent) / 100;
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_set_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH, duty_cycle));
+    BSP_ERROR_CHECK_RETURN_ERR(ledc_update_duty(LEDC_LOW_SPEED_MODE, LCD_LEDC_CH));
+#else
     uint8_t data = (uint8_t)(255 * brightness_percent * 0.01);
     uint8_t chip_addr = 0x45;
     uint8_t data_addr = 0x96;
@@ -475,6 +505,7 @@ esp_err_t bsp_display_brightness_set(int brightness_percent)
     }
 
     i2c_master_bus_rm_device(dev_handle);
+#endif
 
     return ESP_OK;
 }

--- a/bsp/esp32_p4_platform/idf_component.yml
+++ b/bsp/esp32_p4_platform/idf_component.yml
@@ -28,4 +28,4 @@ tags:
 targets:
 - esp32p4
 url: https://github.com/waveshareteam/Waveshare-ESP32-components
-version: 2.0.1
+version: 2.0.2

--- a/bsp/esp32_p4_platform/include/bsp/esp32_p4_platform.h
+++ b/bsp/esp32_p4_platform/include/bsp/esp32_p4_platform.h
@@ -43,9 +43,9 @@
 #define BSP_I2S_DSIN          (GPIO_NUM_11)
 #define BSP_POWER_AMP_IO      (GPIO_NUM_53)
 
-#define BSP_LCD_BACKLIGHT     (GPIO_NUM_NC)
-#define BSP_LCD_RST           (GPIO_NUM_NC)
-#define BSP_LCD_TOUCH_RST     (GPIO_NUM_NC)
+#define BSP_LCD_BACKLIGHT     CONFIG_BSP_LCD_BACKLIGHT
+#define BSP_LCD_RST           CONFIG_BSP_LCD_RST
+#define BSP_LCD_TOUCH_RST     CONFIG_BSP_LCD_TOUCH_RST
 #define BSP_LCD_TOUCH_INT     (GPIO_NUM_NC)
 
 /* uSD card */

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/esp32_p4_wifi6_touch_lcd_7b.c
@@ -638,7 +638,11 @@ lv_indev_t *bsp_display_get_input_dev(void)
     return disp_indev;
 }
 
+#if LVGL_VERSION_MAJOR >= 9
 void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation)
+#else
+void bsp_display_rotate(lv_display_t *disp, lv_disp_rot_t rotation)
+#endif
 {
     lv_disp_set_rotation(disp, rotation);
 }

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/idf_component.yml
@@ -21,4 +21,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-7b.htm
-version: 3.0.0
+version: 3.0.1

--- a/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/esp32_p4_wifi6_touch_lcd_7b.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_7b/include/bsp/esp32_p4_wifi6_touch_lcd_7b.h
@@ -324,7 +324,12 @@ void bsp_display_unlock(void);
  * @param[in] disp Pointer to LVGL display
  * @param[in] rotation Angle of the display rotation
  */
+#if LVGL_VERSION_MAJOR >= 9
 void bsp_display_rotate(lv_display_t *disp, lv_disp_rotation_t rotation);
+#else
+void bsp_display_rotate(lv_display_t *disp, lv_disp_rot_t rotation);
+#endif
+
 #endif // BSP_CONFIG_NO_GRAPHIC_LIB == 0
 
 /**************************************************************************************************


### PR DESCRIPTION
esp32_p4_platform:
- Add Kconfig options for the LCD backlight, LCD reset, and touch reset GPIOs
esp32_p4_wifi6_touch_lcd_7b:
- Adapt the display rotation API for compatibility with LVGL 8 and LVGL 9.