### PR TITLE
fix(bsp): configure XC touch reset GPIO

### DIFF
--- a/bsp/esp32_p4_wifi6_touch_lcd_xc/esp32_p4_wifi6_touch_lcd_xc.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_xc/esp32_p4_wifi6_touch_lcd_xc.c
@@ -957,7 +957,8 @@ esp_err_t bsp_touch_new(const bsp_display_cfg_t *cfg, esp_lcd_touch_handle_t *re
     const esp_lcd_touch_config_t tp_cfg = {
         .x_max = BSP_LCD_H_RES,
         .y_max = BSP_LCD_V_RES,
-        .rst_gpio_num = BSP_LCD_TOUCH_RST, // Shared with LCD reset
+        .rst_gpio_num = BSP_LCD_TOUCH_RST,
+        // TP_INT is not routed to the MCU, so GT911 is polled.
         .int_gpio_num = BSP_LCD_TOUCH_INT,
         .levels = {
             .reset = 0,

--- a/bsp/esp32_p4_wifi6_touch_lcd_xc/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_xc/idf_component.yml
@@ -22,4 +22,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-3.4c.htm
-version: 3.0.1
+version: 3.0.2

--- a/bsp/esp32_p4_wifi6_touch_lcd_xc/include/bsp/esp32_p4_wifi6_touch_lcd_xc.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_xc/include/bsp/esp32_p4_wifi6_touch_lcd_xc.h
@@ -45,7 +45,7 @@
 
 #define BSP_LCD_BACKLIGHT     (GPIO_NUM_26)
 #define BSP_LCD_RST           (GPIO_NUM_27)
-#define BSP_LCD_TOUCH_RST     (GPIO_NUM_NC)
+#define BSP_LCD_TOUCH_RST     (GPIO_NUM_23)
 #define BSP_LCD_TOUCH_INT     (GPIO_NUM_NC)
 
 /* uSD card */


### PR DESCRIPTION
## Summary

- Configure `BSP_LCD_TOUCH_RST` as GPIO23 for ESP32-P4-WIFI6-Touch-LCD-XC.
- Keep `BSP_LCD_TOUCH_INT` as `GPIO_NUM_NC`; TP_INT is not routed to the MCU, so the GT911-compatible touch path remains polling-based.
- Remove the incorrect comment that described touch reset as shared with LCD reset.
- Bump the managed component version from 3.0.1 to 3.0.2.

## Root cause

The board schematics route TP_RST/CTP_RESET through R62 (0 ohm) to GPIO23, while TP_INT/CTP_INT reaches only the TP2 test point. The BSP originally used GPIO23 for touch reset, but a later refactor changed reset to NC and introduced the shared-reset comment. This patch restores the schematic-backed reset pin without enabling an interrupt route that does not exist.

## Impact

The touch controller can now receive the intended hardware reset. Interrupt behavior is unchanged: applications continue to read touch data by polling over I2C.

## Validation

- Reviewed head: `a95610f6f324bb32b2cba4fa347cdf1b892187b0`
- Component self-check passed against `master@663d87f4208c1a06c4141cbbb19ad6b902cc6284`: one changed component, version 3.0.1 to 3.0.2.
- ESP-IDF v5.5.5: clean online dependency resolution and full ESP32-P4 component build passed (1985/1985), followed by a successful final rebuild.
- ESP-IDF v6.0.2: online dependency resolution and full ESP32-P4 component build passed (938/938), followed by a successful final rebuild.
- Both builds resolved `espressif/esp_lcd_touch_gt911` 1.2.1 and recorded app version `a95610f`.
- `git diff --check` passed.

## Hardware validation boundary

This PR is intentionally draft until HIL passes on both the 3.4C and 4C boards. Please cover cold boot, software restart or repeated initialization, both 0x5D and 0x14 address-detection paths, reset timing, and sustained polling. The existing BSP probes the I2C address before the touch driver performs reset, so power-on and recovery behavior should be checked explicitly.

INT/IRQ wake-up is outside the board capability because TP_INT is not routed to the MCU.
