### PR TITLE
fix(bsp/lcd5): resolve esp_lcd_hx8394 from the registry and republish the BSP

### DIFF
--- a/.github/scripts/component_self_check.py
+++ b/.github/scripts/component_self_check.py
@@ -216,12 +216,19 @@ def check_lcd5_hx8394_contract(upload_dirs):
     if codec_version != "~1.5":
         errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected esp_codec_dev ~1.5")
     hx_dependency = dependencies.get("waveshare/esp_lcd_hx8394")
+    # Accept either the immutable git pin (PR/HIL validation phase) or the
+    # published registry release. The registry rejects components whose
+    # dependencies are git-pinned, so released BSP versions must resolve
+    # esp_lcd_hx8394 from the registry.
     if hx_dependency != {
         "git": "https://github.com/waveshareteam/Waveshare-ESP32-components.git",
         "path": "display/lcd/esp_lcd_hx8394",
         "version": "fc6e6d2d63aa314cdcec2e8912614aacff2fbd6d",
-    }:
-        errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected immutable HX8394 PR/HIL validation pin")
+    } and hx_dependency != "^2.1.0":
+        errors.append(
+            f"{LCD5_BSP_DIR}/idf_component.yml: expected waveshare/esp_lcd_hx8394"
+            " ^2.1.0 registry dependency (or the immutable HX8394 PR/HIL git pin)"
+        )
     if bsp_manifest.get("repository") != "https://github.com/waveshareteam/Waveshare-ESP32-components.git":
         errors.append(f"{LCD5_BSP_DIR}/idf_component.yml: expected canonical repository URL")
     bridge = re.compile(

--- a/bsp/esp32_p4_wifi6_touch_lcd_5/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_5/idf_component.yml
@@ -15,11 +15,7 @@ dependencies:
   lvgl/lvgl:
     public: true
     version: '9.5.0'
-  # Temporary immutable PR/HIL validation pin until 2.1.0 is published to the registry.
-  waveshare/esp_lcd_hx8394:
-    git: https://github.com/waveshareteam/Waveshare-ESP32-components.git
-    path: display/lcd/esp_lcd_hx8394
-    version: fc6e6d2d63aa314cdcec2e8912614aacff2fbd6d
+  waveshare/esp_lcd_hx8394: "^2.1.0"
 description: Based on ESP32-P4 chip, waveshare electronics designed a 5-inch screen, highly integrated development board
 repository: https://github.com/waveshareteam/Waveshare-ESP32-components.git
 tags:
@@ -27,4 +23,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-5.htm
-version: 1.0.2
+version: 1.0.3


### PR DESCRIPTION
## Problem

The PR #192 merge triggered the component upload, but the registry
**rejected** `waveshare/esp32_p4_wifi6_touch_lcd_5@1.0.2`:

```
All dependencies of this component must be uploaded to the registry.
Dependency "waveshare/esp_lcd_hx8394" is a git dependency.
```

`esp_lcd_hx8394@2.1.0` itself was published successfully, but the BSP still
carried the immutable PR/HIL git pin, which the registry does not accept.

## Change

- `bsp/esp32_p4_wifi6_touch_lcd_5`: depend on the published
  `waveshare/esp_lcd_hx8394: "^2.1.0"`, bump version `1.0.2 -> 1.0.3`
- `component_self_check.py`: the LCD-5 contract now accepts either the
  registry dependency (release) or the immutable git pin (PR/HIL phase)

After this merges, the master upload publishes a clean `1.0.3` whose only
panel dependency is the registry `2.1.0`.