### PR TITLE
fix(imu): accumulate qmi8658 24-bit timestamp deltas instead of overwriting

### DIFF
--- a/sensor/qmi8658/CHANGELOG.md
+++ b/sensor/qmi8658/CHANGELOG.md
@@ -1,0 +1,7 @@
+# ChangeLog
+
+## v2.0.1 - 2026-08-18
+
+### bugfix:
+
+* Fixed the 24-bit hardware timestamp unwrap in `qmi8658_read_sensor_data()`. It overwrote `dev->timestamp` instead of accumulating onto it, so the value jumped backwards at every counter wrap instead of staying monotonic.

--- a/sensor/qmi8658/idf_component.yml
+++ b/sensor/qmi8658/idf_component.yml
@@ -2,4 +2,4 @@ dependencies:
   idf: '>=5.3.2'
 description: "QMI8658 sensor, adapted by the Waveshare team"
 url: "https://github.com/waveshareteam/Waveshare-ESP32-components/tree/master/sensor/qmi8658"
-version: 2.0.0
+version: 2.0.1

--- a/sensor/qmi8658/include/qmi8658.h
+++ b/sensor/qmi8658/include/qmi8658.h
@@ -125,6 +125,7 @@ typedef struct {
     bool gyro_unit_rads;
     int display_precision;
     uint32_t timestamp;
+    uint32_t last_raw_timestamp;
 } qmi8658_dev_t;
 
 esp_err_t qmi8658_init(qmi8658_dev_t *dev, i2c_master_bus_handle_t bus_handle, uint8_t i2c_addr);

--- a/sensor/qmi8658/qmi8658.c
+++ b/sensor/qmi8658/qmi8658.c
@@ -14,6 +14,7 @@ esp_err_t qmi8658_init(qmi8658_dev_t *dev, i2c_master_bus_handle_t bus_handle, u
     dev->gyro_unit_rads = false;
     dev->display_precision = 6;
     dev->timestamp = 0;
+    dev->last_raw_timestamp = 0;
     
     i2c_device_config_t dev_config = {
         .dev_addr_length = I2C_ADDR_BIT_LEN_7,
@@ -249,14 +250,12 @@ esp_err_t qmi8658_read_sensor_data(qmi8658_dev_t *dev, qmi8658_data_t *data) {
     uint8_t timestamp_buffer[3];
     esp_err_t ret = qmi8658_read_register(dev, QMI8658_TIMESTAMP_L, timestamp_buffer, 3);
     if (ret == ESP_OK) {
-        uint32_t timestamp = ((uint32_t)timestamp_buffer[2] << 16) | 
-                           ((uint32_t)timestamp_buffer[1] << 8) | 
+        uint32_t timestamp = ((uint32_t)timestamp_buffer[2] << 16) |
+                           ((uint32_t)timestamp_buffer[1] << 8) |
                            timestamp_buffer[0];
-        if (timestamp > dev->timestamp) {
-            dev->timestamp = timestamp;
-        } else {
-            dev->timestamp = (timestamp + 0x1000000 - dev->timestamp);
-        }
+        uint32_t delta = (timestamp - dev->last_raw_timestamp) & 0x00FFFFFF;
+        dev->last_raw_timestamp = timestamp;
+        dev->timestamp += delta;
         data->timestamp = dev->timestamp;
     }
     


### PR DESCRIPTION
## Problem

`qmi8658_read_sensor_data()` reads the QMI8658's free-running 24-bit
hardware timestamp counter and is supposed to unwrap it into a
monotonically increasing `dev->timestamp`. Instead it compares the raw
reading against the previous *unwrapped* value and, on the wrap branch,
assigns a new small value instead of accumulating onto the running total:

```c
if (timestamp > dev->timestamp) {
    dev->timestamp = timestamp;
} else {
    dev->timestamp = (timestamp + 0x1000000 - dev->timestamp);
}
```

With a previous value of 16777215 and a new raw reading of 5, this gives
`dev->timestamp = 5 + 16777216 - 16777215 = 6`: the "monotonic" timestamp
drops from 16,777,215 to 6, and this repeats at every wrap. There is also
no field holding the previous raw counter value, which an unwrap needs.

`qmi8658_read_sensor_data()` is the component's primary read call, the one
the README example polls in a loop. Computing `dt` between samples (gyro
integration, dead reckoning) gets a large negative or, since the field is
`uint32_t`, a huge positive delta at every wrap.

## Fix

- Add `last_raw_timestamp` to `qmi8658_dev_t` to hold the previous raw
  counter reading, zeroed in `qmi8658_init()` alongside `timestamp`.
- Replace the branch with a masked-subtraction delta:
  `delta = (timestamp - last_raw_timestamp) & 0x00FFFFFF`, then
  `dev->timestamp += delta`. This handles the wrap with no branch and
  keeps `dev->timestamp` monotonic.
- Bump `sensor/qmi8658` to 2.0.1 and add a `CHANGELOG.md` entry.

`qmi8658_dev_t` is defined in the public header and is caller-allocated
(not calloc'd by the library), so the new field is initialized explicitly
in `qmi8658_init()` the same way the existing `timestamp` field is.

## Validation

Found by source inspection while auditing the driver stack behind the
ESP32-S3-Touch-AMOLED-1.8. I have not run this on QMI8658 hardware, no
hardware test was performed.

Fixes #186