### PR TITLE
fix(bsp): make LCD-3.5 display header self-contained

### DIFF
--- a/bsp/esp32_p4_wifi6_touch_lcd_3_5/idf_component.yml
+++ b/bsp/esp32_p4_wifi6_touch_lcd_3_5/idf_component.yml
@@ -21,4 +21,4 @@ tags:
 targets:
 - esp32p4
 url: https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-3.5.htm
-version: 2.0.1
+version: 2.0.2

--- a/bsp/esp32_p4_wifi6_touch_lcd_3_5/include/bsp/display.h
+++ b/bsp/esp32_p4_wifi6_touch_lcd_3_5/include/bsp/display.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "esp_err.h"
 #include "esp_lcd_types.h"
 #include "sdkconfig.h"
 

--- a/bsp/esp32_p4_wifi6_touch_lcd_3_5/test_app/main/main.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_3_5/test_app/main/main.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "bsp/display.h"
 #include "bsp/esp32_p4_wifi6_touch_lcd_3_5.h"
 
 #if LVGL_VERSION_MAJOR != 8

--- a/bsp/esp32_p4_wifi6_touch_lcd_3_5/test_apps/main/main.c
+++ b/bsp/esp32_p4_wifi6_touch_lcd_3_5/test_apps/main/main.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include "bsp/display.h"
 #include "bsp/esp32_p4_wifi6_touch_lcd_3_5.h"
 
 #if LVGL_VERSION_MAJOR != 9


### PR DESCRIPTION
## Summary

- include `esp_err.h` directly from the public `bsp/display.h` header
- make both LVGL 8 and LVGL 9 compile-contract projects include `bsp/display.h` first
- bump the LCD-3.5 BSP from 2.0.1 to 2.0.2

## Problem

BSP 2.0.1 declares APIs returning `esp_err_t` in `bsp/display.h`, but that public header does not include the definition of `esp_err_t`. A product source that includes `bsp/display.h` directly therefore fails to compile with `unknown type name esp_err_t` under both ESP-IDF v5.5.5 and v6.0.2 unless another header happens to be included first.

## Validation

Local clean component builds completed successfully from commit `3803516`:

- ESP-IDF v5.5.5 + LVGL 8 test project
- ESP-IDF v5.5.5 + LVGL 9 test project
- ESP-IDF v6.0.2 + LVGL 8 test project
- ESP-IDF v6.0.2 + LVGL 9 test project
- component manifest/version/upload policy check
- `git diff --check`
- independent read-only release review with no remaining findings

[GitHub Actions](https://github.com/waveshareteam/Waveshare-ESP32-components/actions/runs/32447935568) also passed on exact head `3803516d4e525f63f6e89f16727c3f7ced65b1fe`: manifest check, both IDF component builds, and the aggregate CI gate.

## Publication boundary

The product repository remains pinned to the already published Registry BSP 2.0.1 and uses a minimal consumer-side include until 2.0.2 is merged and published. It does not use a Git or local-path dependency.

## Hardware validation

Not performed. This patch changes only a public include contract and compile tests; it does not change runtime display or touch behavior.